### PR TITLE
Clean up card formatting

### DIFF
--- a/app/projects/page.tsx
+++ b/app/projects/page.tsx
@@ -1,6 +1,7 @@
 import { createServerClient } from '@/db/supabase-server'
 import { ProjectCard } from '@/components/project-card'
 import { listProjects } from '@/db/project'
+import { CalendarIcon } from '@heroicons/react/24/solid'
 
 export default async function Projects() {
   const supabase = createServerClient()
@@ -20,6 +21,10 @@ export default async function Projects() {
             <h1 className="text-2xl font-bold">
               ACX Forecasting Mini-Grants Round
             </h1>
+            <div className="my-2 text-gray-600">
+              <CalendarIcon className="relative bottom-0.5 mr-1 inline h-6 w-6 text-orange-500" />
+              Auctions close <span className="text-black">Mar 12, 2023</span>
+            </div>
             <div className="mt-2 grid grid-cols-1 gap-4 lg:grid-cols-2">
               {proposalProjects.map((project) => (
                 <ProjectCard

--- a/components/project-card.tsx
+++ b/components/project-card.tsx
@@ -8,12 +8,14 @@ import Link from 'next/link'
 import {
   EllipsisHorizontalCircleIcon,
   CalendarIcon,
+  SparklesIcon,
 } from '@heroicons/react/24/solid'
 import { Txn } from '@/db/txn'
 import { ProjectCardHeader } from './project-card-header'
 import { ProgressBar } from './progress-bar'
 import { Col } from './layout/col'
 import { ChatBubbleLeftEllipsisIcon } from '@heroicons/react/24/outline'
+import clsx from 'clsx'
 
 export function ProjectCard(props: {
   project: Project
@@ -38,8 +40,8 @@ export function ProjectCard(props: {
         href={`projects/${project.slug}`}
         className="group flex flex-1 flex-col justify-between hover:cursor-pointer"
       >
-        <div className="my-3">
-          <h1 className="text-xl font-bold group-hover:underline">
+        <div className="mt-2 mb-4">
+          <h1 className="text-xl font-semibold group-hover:underline">
             {project.title}
           </h1>
           <p className="font-light text-gray-500">{project.blurb}</p>
@@ -78,15 +80,19 @@ function ProjectCardFooter(props: {
                   </span>
                 </span>
               )}
-              {percentRaised > 0.005 && (
-                <span className="mb-1 flex gap-1 text-gray-600">
-                  <EllipsisHorizontalCircleIcon className="h-6 w-6 text-orange-500" />
-                  <span className="text-black">
-                    {formatLargeNumber(percentRaised * 100)}%
-                  </span>
-                  raised
+
+              <span className="mb-1 flex gap-1 text-gray-600">
+                <SparklesIcon
+                  className={clsx(
+                    'h-6 w-6 ',
+                    percentRaised >= 0.005 ? 'text-orange-500' : 'text-gray-400'
+                  )}
+                />
+                <span className="text-black">
+                  {formatLargeNumber(percentRaised * 100)}%
                 </span>
-              )}
+                raised
+              </span>
             </div>
             {numComments > 0 && (
               <div className="flex flex-row items-center gap-2">
@@ -95,7 +101,7 @@ function ProjectCardFooter(props: {
               </div>
             )}
           </div>
-          {percentRaised > 0.005 && <ProgressBar percent={percentRaised} />}
+          <ProgressBar percent={percentRaised} />
         </div>
       )
     default:

--- a/components/project-card.tsx
+++ b/components/project-card.tsx
@@ -8,12 +8,12 @@ import Link from 'next/link'
 import {
   EllipsisHorizontalCircleIcon,
   CalendarIcon,
-  ChatBubbleLeftEllipsisIcon,
 } from '@heroicons/react/24/solid'
 import { Txn } from '@/db/txn'
 import { ProjectCardHeader } from './project-card-header'
 import { ProgressBar } from './progress-bar'
 import { Col } from './layout/col'
+import { ChatBubbleLeftEllipsisIcon } from '@heroicons/react/24/outline'
 
 export function ProjectCard(props: {
   project: Project
@@ -69,24 +69,33 @@ function ProjectCardFooter(props: {
         <div>
           <div className="flex justify-between">
             <div className="flex flex-col">
-              <span className="mb-1 text-gray-600">
-                <CalendarIcon className="relative bottom-0.5 mr-1 inline h-6 w-6 text-orange-500" />
-                Auction closes{' '}
-                <span className="text-black">
-                  {formatDate(project.auction_close)}
+              {project.round !== 'ACX Mini-Grants' && (
+                <span className="mb-1 text-gray-600">
+                  <CalendarIcon className="relative bottom-0.5 mr-1 inline h-6 w-6 text-orange-500" />
+                  Auction closes{' '}
+                  <span className="text-black">
+                    {formatDate(project.auction_close)}
+                  </span>
                 </span>
-              </span>
-              <span className="mb-1 flex gap-1 text-gray-600">
-                <EllipsisHorizontalCircleIcon className="h-6 w-6 text-orange-500" />
-                <span className="text-black">{percentRaised * 100}%</span>raised
-              </span>
+              )}
+              {percentRaised > 0.005 && (
+                <span className="mb-1 flex gap-1 text-gray-600">
+                  <EllipsisHorizontalCircleIcon className="h-6 w-6 text-orange-500" />
+                  <span className="text-black">
+                    {formatLargeNumber(percentRaised * 100)}%
+                  </span>
+                  raised
+                </span>
+              )}
             </div>
-            <div className="flex flex-row items-center gap-2">
-              <ChatBubbleLeftEllipsisIcon className="h-6 w-6 text-gray-400" />
-              <span className="text-gray-500">{numComments}</span>
-            </div>
+            {numComments > 0 && (
+              <div className="flex flex-row items-center gap-2">
+                <ChatBubbleLeftEllipsisIcon className="h-6 w-6 text-gray-400" />
+                <span className="text-gray-500">{numComments}</span>
+              </div>
+            )}
           </div>
-          <ProgressBar percent={percentRaised} />
+          {percentRaised > 0.005 && <ProgressBar percent={percentRaised} />}
         </div>
       )
     default:


### PR DESCRIPTION
Changes:
- Hide % funding and progress bar for unfunded projects
- Hide auction close date for ACX Minigrants (because they're all the same
- Hide comment indicator for cards with no comments

<img width="424" alt="image" src="https://user-images.githubusercontent.com/856034/223308695-b0d35a19-437d-40aa-b1f2-d4d36e3e47a9.png">
