### PR TITLE
Remove descriptions to slim down payload

### DIFF
--- a/app/projects/page.tsx
+++ b/app/projects/page.tsx
@@ -3,10 +3,12 @@ import { listProjects } from '@/db/project'
 import { AllProjectsDisplay } from './all-projects-display'
 import { getRounds } from '@/db/round'
 import { AllRoundsDisplay } from './all-rounds-display'
+import { getObjectSize } from '@/utils/debug'
 
 export default async function Projects() {
   const supabase = createServerClient()
   const projects = await listProjects(supabase)
+  console.log('projects size', getObjectSize(projects))
   const rounds = await getRounds(supabase)
   return (
     <div className="bg-dark-200 max-w-4xl pt-5">

--- a/app/projects/page.tsx
+++ b/app/projects/page.tsx
@@ -3,12 +3,10 @@ import { listProjects } from '@/db/project'
 import { AllProjectsDisplay } from './all-projects-display'
 import { getRounds } from '@/db/round'
 import { AllRoundsDisplay } from './all-rounds-display'
-import { getObjectSize } from '@/utils/debug'
 
 export default async function Projects() {
   const supabase = createServerClient()
   const projects = await listProjects(supabase)
-  console.log('projects size', getObjectSize(projects))
   const rounds = await getRounds(supabase)
   return (
     <div className="bg-dark-200 max-w-4xl pt-5">

--- a/db/project.ts
+++ b/db/project.ts
@@ -54,7 +54,7 @@ export async function listProjects(supabase: SupabaseClient) {
   const { data, error } = await supabase
     .from('projects')
     .select(
-      'title, id, creator, slug, blurb, stage, profiles(*), bids(*), txns(*), comments(id), rounds(title, slug)'
+      'title, id, creator, slug, blurb, stage, profiles(*), bids(id), txns(*), comments(id), rounds(title, slug)'
     )
     .order('created_at', { ascending: false })
   if (error) {

--- a/db/project.ts
+++ b/db/project.ts
@@ -5,6 +5,7 @@ import { Txn } from './txn'
 import { Profile } from './profile'
 import { Comment } from '@/db/comment'
 import { Round } from './round'
+import { getObjectSize } from '@/utils/debug'
 
 export type Project = Database['public']['Tables']['projects']['Row']
 
@@ -75,14 +76,19 @@ export async function getFullProjectBySlug(
   return data[0] as FullProject
 }
 
+// Note: This does not include project or round descriptions, for a smaller payload
 export async function getFullProjectsByRound(
   supabase: SupabaseClient,
   roundTitle: string
 ) {
   const { data, error } = await supabase
     .from('projects')
+    // .select(
+    //   'title, id, creator, slug, blurb, stage, profiles(*), bids(*), txns(*), comments(*), rounds(title, slug)'
+    // )
     .select('*, profiles(*), bids(*), txns(*), comments(*), rounds(*)')
     .eq('round', roundTitle)
+  console.log('getFullProjectsByRound', getObjectSize(data))
   if (error) {
     throw error
   }

--- a/db/project.ts
+++ b/db/project.ts
@@ -5,7 +5,6 @@ import { Txn } from './txn'
 import { Profile } from './profile'
 import { Comment } from '@/db/comment'
 import { Round } from './round'
-import { getObjectSize } from '@/utils/debug'
 
 export type Project = Database['public']['Tables']['projects']['Row']
 
@@ -89,7 +88,6 @@ export async function getFullProjectsByRound(
       'title, id, creator, slug, blurb, stage, profiles(*), bids(*), txns(*), comments(*), rounds(title, slug)'
     )
     .eq('round', roundTitle)
-  console.log('getFullProjectsByRound', getObjectSize(data))
   if (error) {
     throw error
   }

--- a/db/project.ts
+++ b/db/project.ts
@@ -83,10 +83,9 @@ export async function getFullProjectsByRound(
 ) {
   const { data, error } = await supabase
     .from('projects')
-    // .select(
-    //   'title, id, creator, slug, blurb, stage, profiles(*), bids(*), txns(*), comments(*), rounds(title, slug)'
-    // )
-    .select('*, profiles(*), bids(*), txns(*), comments(*), rounds(*)')
+    .select(
+      'title, id, creator, slug, blurb, stage, profiles(*), bids(*), txns(*), comments(*), rounds(title, slug)'
+    )
     .eq('round', roundTitle)
   console.log('getFullProjectsByRound', getObjectSize(data))
   if (error) {

--- a/db/project.ts
+++ b/db/project.ts
@@ -54,7 +54,9 @@ export type FullProject = Project & { profiles: Profile } & {
 export async function listProjects(supabase: SupabaseClient) {
   const { data, error } = await supabase
     .from('projects')
-    .select('*, profiles(*), bids(*), txns(*), comments(*), rounds(*)')
+    .select(
+      'title, id, creator, slug, blurb, stage, profiles(*), bids(*), txns(*), comments(id), rounds(title, slug)'
+    )
     .order('created_at', { ascending: false })
   if (error) {
     throw error

--- a/utils/debug.ts
+++ b/utils/debug.ts
@@ -1,0 +1,26 @@
+// Calculate the size of this javascript object in memory; to make sure Supabase responses aren't too large
+// https://stackoverflow.com/a/11900218/1123955
+export function getObjectSize(obj: any) {
+  var objectList = []
+  var stack = [obj]
+  var bytes = 0
+
+  while (stack.length) {
+    var value = stack.pop()
+
+    if (typeof value === 'boolean') {
+      bytes += 4
+    } else if (typeof value === 'string') {
+      bytes += value.length * 2
+    } else if (typeof value === 'number') {
+      bytes += 8
+    } else if (typeof value === 'object' && objectList.indexOf(value) === -1) {
+      objectList.push(value)
+
+      for (var i in value) {
+        stack.push(value[i])
+      }
+    }
+  }
+  return bytes
+}


### PR DESCRIPTION
So, it turns out one reason why the OP round page has been stuck at 4 projects, is that our payload size has been way too large, to fit into our cache. The reason is that we're sending over the project descriptions, in addition to duplicated round descriptions.


```
  const { data, error } = await supabase
    .from('projects')
    .select('*, profiles(*), bids(*), txns(*), comments(*), rounds(*)')
    .eq('round', roundTitle)
  console.log('getFullProjectsByRound', getObjectSize(data))
```
getFullProjectsByRound 1275574 - that's 1mb+, which is absolutely giant for text data

vs

```
  const { data, error } = await supabase
    .from('projects')
    .select(
      'title, id, creator, slug, blurb, stage, profiles(*), bids(*), txns(*), comments(*), rounds(title, slug)'
    )
    .eq('round', roundTitle)
```
getFullProjectsByRound 16076 - 16kB, much more reasonable

Moving forward, we should be careful not to include descriptions where it's not necessary (eg on the card list views) so that we send much less data, making the page load times and transitions much faster.

However, with this change, it's not quite accurate to say that these the returned objects include FullProjects - because round data and description, as well as any other columns, are no longer present. I'm not sure what a good longer-term code architecture solution for this will be, as we might run into places where the code expects certain fields but they're not included in the query...