### PR TITLE
Clarify onboarding UI

### DIFF
--- a/app/create-grant/create-grant-form.tsx
+++ b/app/create-grant/create-grant-form.tsx
@@ -161,15 +161,13 @@ export function CreateGrantForm(props: {
             : ''
         )}
       >
-        <Row className="h-6 items-center">
-          <Checkbox
-            id="terms"
-            aria-describedby="terms-description"
-            name="terms"
-            checked={recipientOnManifund}
-            onChange={() => setRecipientOnManifund(!recipientOnManifund)}
-          />
-        </Row>
+        <Checkbox
+          id="terms"
+          aria-describedby="terms-description"
+          name="terms"
+          checked={recipientOnManifund}
+          onChange={() => setRecipientOnManifund(!recipientOnManifund)}
+        />
         <span className="ml-2 leading-6 text-gray-900">
           Recipient is already a user on Manifund.
         </span>
@@ -393,15 +391,13 @@ export function CreateGrantForm(props: {
         <TextEditor editor={reasoningEditor} />
       </Col>
       <Row>
-        <Row className="h-6 items-center">
-          <Checkbox
-            id="terms"
-            aria-describedby="terms-description"
-            name="terms"
-            checked={agreedToTerms}
-            onChange={() => setAgreedToTerms(!agreedToTerms)}
-          />
-        </Row>
+        <Checkbox
+          id="terms"
+          aria-describedby="terms-description"
+          name="terms"
+          checked={agreedToTerms}
+          onChange={() => setAgreedToTerms(!agreedToTerms)}
+        />
         <div className="ml-3 text-sm leading-6">
           <label htmlFor="terms" className="font-medium text-gray-900">
             Check this box to confirm:

--- a/app/create-grant/create-grant-form.tsx
+++ b/app/create-grant/create-grant-form.tsx
@@ -1,6 +1,6 @@
 'use client'
 import { TextEditor, useTextEditor } from '@/components/editor'
-import { Input } from '@/components/input'
+import { Checkbox, Input } from '@/components/input'
 import { Col } from '@/components/layout/col'
 import { useEffect, useState } from 'react'
 import { CheckIcon, ChevronUpDownIcon } from '@heroicons/react/24/outline'
@@ -162,12 +162,10 @@ export function CreateGrantForm(props: {
         )}
       >
         <Row className="h-6 items-center">
-          <input
+          <Checkbox
             id="terms"
             aria-describedby="terms-description"
             name="terms"
-            type="checkbox"
-            className="h-4 w-4 rounded border-gray-300 text-orange-600 focus:ring-orange-600"
             checked={recipientOnManifund}
             onChange={() => setRecipientOnManifund(!recipientOnManifund)}
           />

--- a/app/create-grant/create-grant-form.tsx
+++ b/app/create-grant/create-grant-form.tsx
@@ -394,12 +394,10 @@ export function CreateGrantForm(props: {
       </Col>
       <Row>
         <Row className="h-6 items-center">
-          <input
+          <Checkbox
             id="terms"
             aria-describedby="terms-description"
             name="terms"
-            type="checkbox"
-            className="h-4 w-4 rounded border-gray-300 text-orange-600 focus:ring-orange-600"
             checked={agreedToTerms}
             onChange={() => setAgreedToTerms(!agreedToTerms)}
           />

--- a/app/create/create-project-form.tsx
+++ b/app/create/create-project-form.tsx
@@ -19,7 +19,7 @@ import { ArrowRightIcon } from '@heroicons/react/24/solid'
 import { Col } from '@/components/layout/col'
 import { Row } from '@/components/layout/row'
 import { Card } from '@/components/card'
-import { RadioGroup } from '@headlessui/react'
+import { Checkbox } from '@/components/input'
 import { HorizontalRadioGroup } from '@/components/radio-group'
 
 const DEFAULT_DESCRIPTION = `
@@ -403,12 +403,10 @@ export function CreateProjectForm(props: { rounds: Round[] }) {
       {projectType === 'cert' && (
         <Row className="mb-3">
           <Row className="h-6 items-center">
-            <input
+            <Checkbox
               id="terms"
               aria-describedby="terms-description"
               name="terms"
-              type="checkbox"
-              className="h-4 w-4 rounded border-gray-300 text-orange-600 focus:ring-orange-600"
               checked={agreedToTerms}
               onChange={() => setAgreedToTerms(!agreedToTerms)}
             />

--- a/app/create/create-project-form.tsx
+++ b/app/create/create-project-form.tsx
@@ -402,16 +402,13 @@ export function CreateProjectForm(props: { rounds: Round[] }) {
       )}
       {projectType === 'cert' && (
         <Row className="mb-3">
-          <Row className="h-6 items-center">
-            <Checkbox
-              id="terms"
-              aria-describedby="terms-description"
-              name="terms"
-              checked={agreedToTerms}
-              onChange={() => setAgreedToTerms(!agreedToTerms)}
-            />
-          </Row>
-
+          <Checkbox
+            id="terms"
+            aria-describedby="terms-description"
+            name="terms"
+            checked={agreedToTerms}
+            onChange={() => setAgreedToTerms(!agreedToTerms)}
+          />
           <div className="ml-3 text-sm leading-6">
             <label htmlFor="terms" className="font-medium text-gray-900">
               Check this box to confirm that you understand and commit to the

--- a/app/edit-profile/edit-profile.tsx
+++ b/app/edit-profile/edit-profile.tsx
@@ -12,11 +12,8 @@ import uuid from 'react-uuid'
 import Image from 'next/image'
 import { SUPABASE_BUCKET_URL } from '@/db/env'
 import { TextEditor, useTextEditor } from '@/components/editor'
-import clsx from 'clsx'
 import { Row } from '@/components/layout/row'
 import { Col } from '@/components/layout/col'
-import { Card } from '@/components/card'
-import Link from 'next/link'
 
 export function EditProfileForm(props: { profile: Profile }) {
   const { profile } = props

--- a/app/edit-profile/edit-profile.tsx
+++ b/app/edit-profile/edit-profile.tsx
@@ -160,12 +160,18 @@ export function EditProfileForm(props: { profile: Profile }) {
             </span>
           </div>
         </Row>
-        <Row className="gap-2">
+        <Row className="relative gap-2">
           <Checkbox
             id="accredited-investor"
             checked={profile.accreditation_status}
             disabled
           />
+          {!profile.accreditation_status && (
+            <a
+              className="absolute z-10 h-5 w-5"
+              href="https://airtable.com/shrZVLeo6f34NBfR0"
+            />
+          )}
           <div className="relative top-0.5 text-sm">
             <span className="font-semibold">Accredited investor: </span>
             <span className="text-gray-500">

--- a/app/edit-profile/edit-profile.tsx
+++ b/app/edit-profile/edit-profile.tsx
@@ -4,7 +4,7 @@ import { useSupabase } from '@/db/supabase-provider'
 import { SupabaseClient } from '@supabase/supabase-js'
 import { useState } from 'react'
 import { Avatar } from '@/components/avatar'
-import { Input } from '@/components/input'
+import { Checkbox, Input } from '@/components/input'
 import { Button } from '@/components/button'
 import { useRouter } from 'next/navigation'
 import { Profile } from '@/db/profile'
@@ -16,6 +16,7 @@ import clsx from 'clsx'
 import { Row } from '@/components/layout/row'
 import { Col } from '@/components/layout/col'
 import { Card } from '@/components/card'
+import Link from 'next/link'
 
 export function EditProfileForm(props: { profile: Profile }) {
   const { profile } = props
@@ -144,97 +145,52 @@ export function EditProfileForm(props: { profile: Profile }) {
         <TextEditor editor={editor} />
       </Col>
       <Col className="gap-1">
-        <label htmlFor="regranterStatus">Regranter status</label>
-        <Card>
-          <Row className="w-full justify-between">
-            <p className="font-medium">
-              {regranterStatus ? 'Regranter' : 'Non-regranter'}
-            </p>
-            <button
-              type="button"
-              id="regranterStatus"
-              className={clsx(
-                'relative mb-3 inline-flex h-6 w-11 flex-shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus:outline-none focus:ring-2 focus:ring-orange-500 focus:ring-offset-2' +
-                  (regranterStatus ? ' bg-orange-500' : ' bg-gray-200'),
-                'focus:ring-offset-gray-100'
-              )}
-              role="switch"
-              aria-checked="false"
-              onClick={() =>
-                setRegranterStatus((regranterStatus) => !regranterStatus)
-              }
-            >
-              <span className="sr-only">Regranter status</span>
-              <span
-                aria-hidden="true"
-                className={clsx(
-                  'pointer-events-none inline-block h-5 w-5 transform rounded-full bg-white ring-0 transition duration-200 ease-in-out',
-                  regranterStatus ? 'translate-x-5' : 'translate-x-0'
-                )}
-              ></span>
-            </button>
-          </Row>
-          {regranterStatus ? (
-            <div className="mt-3 rounded-md bg-emerald-100 p-3 text-center text-emerald-600">
-              You will be listed as a regranter. Other users will be able to
-              transfer funds to you, and you will be expected to regrant those
-              funds to other projects, including projects not listed on
-              Manifund, to the best of your ability.
-            </div>
-          ) : (
-            <div className="mt-3 rounded-md bg-rose-100 p-3 text-center text-rose-600">
-              You will not be listed as a regranter. You can still give to
-              projects listed on Manifund, but cannot create grants for projects
-              not listed on Manifund.
-            </div>
-          )}
-        </Card>
-      </Col>
-      <Col className="gap-1">
-        <label>Investor status</label>
-        <Card>
-          <p className="font-medium">
-            {profile.accreditation_status ? 'Accredited' : 'Not Accredited'}
-          </p>
-          {profile.accreditation_status ? (
-            <div className="mt-3 rounded-md bg-emerald-100 p-3 text-center text-emerald-600">
-              You can invest in impact certificates with real money and withdraw
-              your profits.
-            </div>
-          ) : (
-            <div className="mt-3 rounded-md bg-rose-100 p-3 text-center text-rose-600">
-              You can invest in impact certificates with money in your Manifund
-              account, grow your portfolio, and donate your balance to real
-              charities, but you cannot withdraw your money. Deposits to your
-              Manifund account are tax-deductible donations, which is not true
-              of accredited investors. If you want to withdraw your profits, you
-              will need to fill out{' '}
+        <label>Roles and capabilities</label>
+        <Row className="gap-2">
+          <Checkbox
+            id="regrantor"
+            checked={regranterStatus}
+            onChange={() =>
+              setRegranterStatus((regranterStatus) => !regranterStatus)
+            }
+          />
+          <div className="relative top-0.5 text-sm">
+            <span className="font-semibold">Regrantor: </span>
+            <span className="text-gray-500">
+              as a regrantor, you can recieve charitable funds from other users
+              and give grants to projects, including projects not yet listed on
+              Manifund.
+            </span>
+          </div>
+        </Row>
+        <Row className="gap-2">
+          <Checkbox
+            id="accredited-investor"
+            checked={profile.accreditation_status}
+            disabled
+          />
+          <div className="relative top-0.5 text-sm">
+            <span className="font-semibold">Accredited investor: </span>
+            <span className="text-gray-500">
+              as an accredited investor, you can invest in impact certificates
+              with real money and withdraw your profits. If you are
+              unaccredited, you can still invest but profits can only be used
+              for charitable purposes.{' '}
               <a
-                target="_blank"
-                rel="noopener noreferrer"
                 href="https://airtable.com/shrZVLeo6f34NBfR0"
-                className="font-bold hover:underline"
+                className="font-semibold text-black hover:underline"
               >
-                this form
+                Use this form
               </a>{' '}
-              to get verified as an accredited investor.
-              <br />
-              <br />
-              <span className="font-bold">
-                To avoid potential mixing of funds, you cannot have any balance
-                on your Manifund account when you&apos;re verified as an
-                accredited investor
-              </span>
-              <span>
-                , so if you intend to become verified, please do so first before
-                depositing funds.
-              </span>
-            </div>
-          )}
-        </Card>
+              to get verified as an accredited investor. To avoid mixing of
+              funds, you cannot hold any money or investments in your Manifund
+              account at the time of verification.
+            </span>
+          </div>
+        </Row>
       </Col>
-      <label htmlFor="avatar">Choose a profile picture.</label>
-      <div className="flex space-x-2">
+      <label htmlFor="avatar">Choose a profile picture</label>
+      <Row className="flex space-x-2">
         <div className="h-24 w-24">
           {avatar ? (
             <Image
@@ -253,7 +209,7 @@ export function EditProfileForm(props: { profile: Profile }) {
             />
           )}
         </div>
-      </div>
+      </Row>
       <input
         type="file"
         id="avatar"

--- a/app/projects/[slug]/agreement/sign-agreement.tsx
+++ b/app/projects/[slug]/agreement/sign-agreement.tsx
@@ -14,15 +14,13 @@ export function SignAgreement(props: { project: ProjectAndProfile }) {
   return (
     <>
       <Row className="mb-3">
-        <Row className="h-6 items-center">
-          <Checkbox
-            id="terms"
-            aria-describedby="terms-description"
-            name="terms"
-            checked={agreed}
-            onChange={() => setAgreed(!agreed)}
-          />
-        </Row>
+        <Checkbox
+          id="terms"
+          aria-describedby="terms-description"
+          name="terms"
+          checked={agreed}
+          onChange={() => setAgreed(!agreed)}
+        />
         <div className="ml-3 text-sm leading-6">
           <label htmlFor="terms" className="font-medium text-gray-900">
             I, <strong>{project.profiles.full_name}</strong>, agree to the terms

--- a/app/projects/[slug]/agreement/sign-agreement.tsx
+++ b/app/projects/[slug]/agreement/sign-agreement.tsx
@@ -1,5 +1,6 @@
 'use client'
 import { Button } from '@/components/button'
+import { Checkbox } from '@/components/input'
 import { Row } from '@/components/layout/row'
 import { ProjectAndProfile } from '@/db/project'
 import { useRouter } from 'next/navigation'
@@ -14,12 +15,10 @@ export function SignAgreement(props: { project: ProjectAndProfile }) {
     <>
       <Row className="mb-3">
         <Row className="h-6 items-center">
-          <input
+          <Checkbox
             id="terms"
             aria-describedby="terms-description"
             name="terms"
-            type="checkbox"
-            className="h-4 w-4 rounded border-gray-300 text-orange-600 focus:ring-orange-600"
             checked={agreed}
             onChange={() => setAgreed(!agreed)}
           />

--- a/app/projects/[slug]/bids.tsx
+++ b/app/projects/[slug]/bids.tsx
@@ -11,7 +11,7 @@ import { CircleStackIcon, TrashIcon } from '@heroicons/react/24/outline'
 import { useRouter } from 'next/navigation'
 import { useState } from 'react'
 import { MySlider } from '@/components/slider'
-import { Input } from '@/components/input'
+import { Checkbox, Input } from '@/components/input'
 import { useSupabase } from '@/db/supabase-provider'
 import { Modal } from '@/components/modal'
 import { Profile } from '@/db/profile'
@@ -237,12 +237,10 @@ function Trade(props: {
               project.round === 'OP AI Worldviews Contest' && (
                 <div className="mb-3 flex">
                   <div className="flex h-6 items-center">
-                    <input
+                    <Checkbox
                       id="terms"
                       aria-describedby="terms-description"
                       name="terms"
-                      type="checkbox"
-                      className="h-4 w-4 rounded border-gray-300 text-orange-600 focus:ring-orange-600"
                       checked={agreedToTerms}
                       onChange={() => setAgreedToTerms(!agreedToTerms)}
                     />

--- a/app/projects/[slug]/bids.tsx
+++ b/app/projects/[slug]/bids.tsx
@@ -236,15 +236,13 @@ function Trade(props: {
             {project.creator === userId &&
               project.round === 'OP AI Worldviews Contest' && (
                 <div className="mb-3 flex">
-                  <div className="flex h-6 items-center">
-                    <Checkbox
-                      id="terms"
-                      aria-describedby="terms-description"
-                      name="terms"
-                      checked={agreedToTerms}
-                      onChange={() => setAgreedToTerms(!agreedToTerms)}
-                    />
-                  </div>
+                  <Checkbox
+                    id="terms"
+                    aria-describedby="terms-description"
+                    name="terms"
+                    checked={agreedToTerms}
+                    onChange={() => setAgreedToTerms(!agreedToTerms)}
+                  />
                   <div className="ml-3 text-sm leading-6">
                     <label
                       htmlFor="terms"

--- a/components/input.tsx
+++ b/components/input.tsx
@@ -1,6 +1,7 @@
 /* eslint-disable react/display-name */
 import clsx from 'clsx'
 import { forwardRef, Ref } from 'react'
+import { Row } from './layout/row'
 
 /** Text input. Wraps html `<input>` */
 export const Input = forwardRef(
@@ -30,15 +31,17 @@ export const Checkbox = forwardRef(
   (props: JSX.IntrinsicElements['input'], ref: Ref<HTMLInputElement>) => {
     const { className, ...rest } = props
     return (
-      <input
-        ref={ref}
-        type="checkbox"
-        className={clsx(
-          'h-4 w-4 rounded border-gray-300 text-orange-600 focus:ring-orange-600',
-          className
-        )}
-        {...rest}
-      />
+      <Row className="h-6 items-center">
+        <input
+          ref={ref}
+          type="checkbox"
+          className={clsx(
+            'h-4 w-4 rounded border-gray-300 text-orange-600 focus:ring-orange-600',
+            className
+          )}
+          {...rest}
+        />
+      </Row>
     )
   }
 )

--- a/components/input.tsx
+++ b/components/input.tsx
@@ -25,3 +25,20 @@ export const Input = forwardRef(
     )
   }
 )
+
+export const Checkbox = forwardRef(
+  (props: JSX.IntrinsicElements['input'], ref: Ref<HTMLInputElement>) => {
+    const { className, ...rest } = props
+    return (
+      <input
+        ref={ref}
+        type="checkbox"
+        className={clsx(
+          'h-4 w-4 rounded border-gray-300 text-orange-600 focus:ring-orange-600',
+          className
+        )}
+        {...rest}
+      />
+    )
+  }
+)


### PR DESCRIPTION
Replace big regrantor & accredited investor cards with checkboxes. Accredited checkbox is disabled but the description links to the verification form—maybe that's also confusing. But the regrantor checkbox directly edits that status.

<img width="550" alt="Screen Shot 2023-07-04 at 10 29 10 AM" src="https://github.com/manifoldmarkets/manifund/assets/116405486/c0dfbcdd-d6b5-4760-a834-64b180ca7768">
