### PR TITLE
Setup regranting 2024

### DIFF
--- a/app/[usernameSlug]/profile-content.tsx
+++ b/app/[usernameSlug]/profile-content.tsx
@@ -19,6 +19,9 @@ import { Row } from '@/components/layout/row'
 import { useState } from 'react'
 import clsx from 'clsx'
 import { RightCarrotIcon } from '@/components/icons'
+import { Button } from '@/components/button'
+import { Input } from '@/components/input'
+import { useRouter } from 'next/navigation'
 
 export function ProfileContent(props: {
   profile: Profile
@@ -95,6 +98,10 @@ export function ProfileContent(props: {
         (project.stage !== 'hidden' && project.stage !== 'draft') ||
         isOwnProfile
     )
+  const [balanceToClear, setBalanceToClear] = useState(0)
+  const [submitting, setSubmitting] = useState(false)
+  const router = useRouter()
+  console.log(balanceToClear, submitting)
   return (
     <div className="flex flex-col gap-6">
       {profile.regranter_status && !isOwnProfile && (
@@ -104,6 +111,29 @@ export function ProfileContent(props: {
           maxDonation={userCharityBalance}
         />
       )}
+      <Input
+        type="number"
+        onChange={(e) => setBalanceToClear(Number(e.target.value))}
+      />
+      <Button
+        disabled={balanceToClear <= 0 || submitting}
+        loading={submitting}
+        onClick={async () => {
+          setSubmitting(true)
+          await fetch('/api/transfer-money', {
+            method: 'POST',
+            body: JSON.stringify({
+              fromId: profile.id,
+              toId: process.env.NEXT_PUBLIC_PROD_BANK_ID,
+              amount: balanceToClear,
+            }),
+          })
+          router.refresh()
+          setSubmitting(false)
+        }}
+      >
+        Clear balance
+      </Button>
       <BalanceDisplay
         balance={balance}
         // Hack to get around old accounting system which means some cash balances are negative

--- a/app/[usernameSlug]/profile-content.tsx
+++ b/app/[usernameSlug]/profile-content.tsx
@@ -19,10 +19,6 @@ import { Row } from '@/components/layout/row'
 import { useState } from 'react'
 import clsx from 'clsx'
 import { RightCarrotIcon } from '@/components/icons'
-import { Button } from '@/components/button'
-import { Input } from '@/components/input'
-import { useRouter } from 'next/navigation'
-
 export function ProfileContent(props: {
   profile: Profile
   projects: FullProject[]
@@ -98,10 +94,6 @@ export function ProfileContent(props: {
         (project.stage !== 'hidden' && project.stage !== 'draft') ||
         isOwnProfile
     )
-  const [balanceToClear, setBalanceToClear] = useState(0)
-  const [submitting, setSubmitting] = useState(false)
-  const router = useRouter()
-  console.log(balanceToClear, submitting)
   return (
     <div className="flex flex-col gap-6">
       {profile.regranter_status && !isOwnProfile && (
@@ -111,29 +103,6 @@ export function ProfileContent(props: {
           maxDonation={userCharityBalance}
         />
       )}
-      <Input
-        type="number"
-        onChange={(e) => setBalanceToClear(Number(e.target.value))}
-      />
-      <Button
-        disabled={balanceToClear <= 0 || submitting}
-        loading={submitting}
-        onClick={async () => {
-          setSubmitting(true)
-          await fetch('/api/transfer-money', {
-            method: 'POST',
-            body: JSON.stringify({
-              fromId: profile.id,
-              toId: process.env.NEXT_PUBLIC_PROD_BANK_ID,
-              amount: balanceToClear,
-            }),
-          })
-          router.refresh()
-          setSubmitting(false)
-        }}
-      >
-        Clear balance
-      </Button>
       <BalanceDisplay
         balance={balance}
         // Hack to get around old accounting system which means some cash balances are negative

--- a/app/about/regranting/page.tsx
+++ b/app/about/regranting/page.tsx
@@ -12,7 +12,7 @@ export default async function RegrantingPage() {
         <p>
           For our regranting program, we work with donors to delegate a
           grantmaking budget to individuals known as “regrantors”. Regrantors
-          independently make grant decisions, based on their own expertise.
+          independently make grant decisions based on their own expertise.
         </p>
         {/* <p>
           This model was pioneered by the FTX Future Fund; among the grantmaking

--- a/app/about/regranting/page.tsx
+++ b/app/about/regranting/page.tsx
@@ -1,28 +1,10 @@
-import { ProfileCard } from '@/components/profile-card'
-import { getRegranters, Profile } from '@/db/profile'
+import { getRegranters } from '@/db/profile'
 import { createServerClient } from '@/db/supabase-server'
-import {
-  getSponsoredAmount2023,
-  getSponsoredAmount2024,
-} from '@/utils/constants'
-import { sortBy } from 'lodash'
 import { RegrantorsDisplay } from './regrantors-display'
 
 export default async function RegrantingPage() {
   const supabase = createServerClient()
   const regrantors = await getRegranters(supabase)
-  const sortedRegranters = sortBy(
-    sortBy(regrantors, [
-      function (regranter: Profile) {
-        return -getSponsoredAmount2023(regranter.id)
-      },
-    ]),
-    [
-      function (regranter: Profile) {
-        return -getSponsoredAmount2024(regranter.id)
-      },
-    ]
-  )
   return (
     <div className="mx-auto max-w-3xl p-5">
       <div className="prose mx-auto max-w-none font-light">
@@ -40,7 +22,7 @@ export default async function RegrantingPage() {
           </a>
         </p> */}
       </div>
-      <RegrantorsDisplay regrantors={sortedRegranters} />
+      <RegrantorsDisplay regrantors={regrantors} />
       <div className="prose mx-auto max-w-none font-light">
         <h3>Why regranting?</h3>
         <ul>

--- a/app/about/regranting/page.tsx
+++ b/app/about/regranting/page.tsx
@@ -13,8 +13,8 @@ export default async function RegrantingPage() {
     },
   ])
   return (
-    <div className="p-5">
-      <div className="prose mx-auto font-light">
+    <div className="mx-auto max-w-3xl p-5">
+      <div className="prose mx-auto max-w-none font-light">
         <h1>Regranting</h1>
         <p>
           For our regranting program, we work with donors to delegate a
@@ -29,14 +29,14 @@ export default async function RegrantingPage() {
             considered regranting to be the most promising.
           </a>
         </p> */}
+        <h3>Our regrantors</h3>
       </div>
-      <h3 className="my-8 text-center text-2xl font-bold">Our regrantors</h3>
-      <div className="mx-auto mb-5 mt-2 grid max-w-4xl grid-cols-2 gap-4 px-5 sm:grid-cols-3">
+      <div className="mx-auto mb-5 mt-2 grid grid-cols-2 gap-4 sm:grid-cols-3">
         {sortedRegranters.map((regranter) => {
           return <ProfileCard key={regranter.id} profile={regranter} />
         })}
       </div>
-      <div className="prose mx-auto font-light">
+      <div className="prose mx-auto max-w-none font-light">
         <h3>Why regranting?</h3>
         <ul>
           <li>

--- a/app/about/regranting/page.tsx
+++ b/app/about/regranting/page.tsx
@@ -1,17 +1,27 @@
 import { ProfileCard } from '@/components/profile-card'
 import { getRegranters, Profile } from '@/db/profile'
 import { createServerClient } from '@/db/supabase-server'
-import { getSponsoredAmount2023 } from '@/utils/constants'
+import {
+  getSponsoredAmount2023,
+  getSponsoredAmount2024,
+} from '@/utils/constants'
 import { sortBy } from 'lodash'
 
 export default async function RegrantingPage() {
   const supabase = createServerClient()
   const regrantors = await getRegranters(supabase)
-  const sortedRegranters = sortBy(regrantors, [
-    function (regranter: Profile) {
-      return -getSponsoredAmount2023(regranter.id)
-    },
-  ])
+  const sortedRegranters = sortBy(
+    sortBy(regrantors, [
+      function (regranter: Profile) {
+        return -getSponsoredAmount2023(regranter.id)
+      },
+    ]),
+    [
+      function (regranter: Profile) {
+        return -getSponsoredAmount2024(regranter.id)
+      },
+    ]
+  )
   return (
     <div className="mx-auto max-w-3xl p-5">
       <div className="prose mx-auto max-w-none font-light">

--- a/app/about/regranting/page.tsx
+++ b/app/about/regranting/page.tsx
@@ -1,7 +1,7 @@
 import { ProfileCard } from '@/components/profile-card'
 import { getRegranters, Profile } from '@/db/profile'
 import { createServerClient } from '@/db/supabase-server'
-import { getSponsoredAmount } from '@/utils/constants'
+import { getSponsoredAmount2023 } from '@/utils/constants'
 import { sortBy } from 'lodash'
 
 export default async function RegrantingPage() {
@@ -9,7 +9,7 @@ export default async function RegrantingPage() {
   const regrantors = await getRegranters(supabase)
   const sortedRegranters = sortBy(regrantors, [
     function (regranter: Profile) {
-      return -getSponsoredAmount(regranter.id)
+      return -getSponsoredAmount2023(regranter.id)
     },
   ])
   return (
@@ -19,8 +19,7 @@ export default async function RegrantingPage() {
         <p>
           For our regranting program, we work with donors to delegate a
           grantmaking budget to individuals known as “regrantors”. Regrantors
-          independently make grant decisions, based on the goals of the original
-          donor, and their own expertise.
+          independently make grant decisions, based on their own expertise.
         </p>
         {/* <p>
           This model was pioneered by the FTX Future Fund; among the grantmaking

--- a/app/about/regranting/page.tsx
+++ b/app/about/regranting/page.tsx
@@ -6,6 +6,7 @@ import {
   getSponsoredAmount2024,
 } from '@/utils/constants'
 import { sortBy } from 'lodash'
+import { RegrantorsDisplay } from './regrantors-display'
 
 export default async function RegrantingPage() {
   const supabase = createServerClient()
@@ -38,13 +39,8 @@ export default async function RegrantingPage() {
             considered regranting to be the most promising.
           </a>
         </p> */}
-        <h3>Our regrantors</h3>
       </div>
-      <div className="mx-auto mb-5 mt-2 grid grid-cols-2 gap-4 sm:grid-cols-3">
-        {sortedRegranters.map((regranter) => {
-          return <ProfileCard key={regranter.id} profile={regranter} />
-        })}
-      </div>
+      <RegrantorsDisplay regrantors={sortedRegranters} />
       <div className="prose mx-auto max-w-none font-light">
         <h3>Why regranting?</h3>
         <ul>

--- a/app/about/regranting/regrantors-display.tsx
+++ b/app/about/regranting/regrantors-display.tsx
@@ -3,35 +3,24 @@
 import { Row } from '@/components/layout/row'
 import { ProfileCard } from '@/components/profile-card'
 import { Profile } from '@/db/profile'
-import {
-  getSponsoredAmount2023,
-  getSponsoredAmount2024,
-} from '@/utils/constants'
+import { getSponsoredAmount } from '@/utils/constants'
 import clsx from 'clsx'
 import { sortBy } from 'lodash'
 import { useState } from 'react'
 
+const YEARS = [2023, 2024]
+
 export function RegrantorsDisplay(props: { regrantors: Profile[] }) {
   const { regrantors } = props
-  const sortedRegrantors2023 = sortBy(
-    regrantors.filter((r) => getSponsoredAmount2023(r.id) !== 0),
-    [
-      function (regranter: Profile) {
-        return -getSponsoredAmount2023(regranter.id)
-      },
-    ]
-  )
-  const sortedRegrantors2024 = sortBy(
-    regrantors.filter((r) => getSponsoredAmount2024(r.id) !== 0),
-    [
-      function (regranter: Profile) {
-        return -getSponsoredAmount2024(regranter.id)
-      },
-    ]
-  )
   const [selectedYear, setSelectedYear] = useState(2024)
-  const regrantorsToShow =
-    selectedYear === 2023 ? sortedRegrantors2023 : sortedRegrantors2024
+  const regrantorsToShow = regrantors.filter(
+    (regrantor) => getSponsoredAmount(regrantor.id, selectedYear) !== 0
+  )
+  const sortedRegrantors = sortBy(regrantorsToShow, [
+    function (regrantor: Profile) {
+      return -getSponsoredAmount(regrantor.id, selectedYear)
+    },
+  ])
   return (
     <div className="mt-5">
       <Row className="justify-between">
@@ -39,40 +28,28 @@ export function RegrantorsDisplay(props: { regrantors: Profile[] }) {
           Our regrantors
         </h3>
         <Row className="gap-3">
-          <button
-            onClick={() => setSelectedYear(2023)}
-            className={clsx(
-              'rounded-md px-3 py-2 text-sm font-medium',
-              selectedYear === 2023
-                ? 'bg-orange-100 text-orange-600'
-                : 'text-gray-500 hover:text-gray-700'
-            )}
-          >
-            2023
-          </button>
-          <button
-            onClick={() => setSelectedYear(2024)}
-            className={clsx(
-              'rounded-md px-3 py-2 text-sm font-medium',
-              selectedYear === 2024
-                ? 'bg-orange-100 text-orange-600'
-                : 'text-gray-500 hover:text-gray-700'
-            )}
-          >
-            2024
-          </button>
+          {YEARS.map((year) => (
+            <button
+              key={year}
+              onClick={() => setSelectedYear(year)}
+              className={clsx(
+                'rounded-md px-3 py-2 text-sm font-medium',
+                selectedYear === year
+                  ? 'bg-orange-100 text-orange-600'
+                  : 'text-gray-500 hover:text-gray-700'
+              )}
+            >
+              {year}
+            </button>
+          ))}
         </Row>
       </Row>
       <div className="mx-auto mb-5 mt-2 grid grid-cols-2 gap-4 sm:grid-cols-3">
-        {regrantorsToShow.map((regrantor) => {
+        {sortedRegrantors.map((regrantor) => {
           return (
             <ProfileCard
               key={regrantor.id}
-              sponsoredAmount={
-                selectedYear === 2024
-                  ? getSponsoredAmount2024(regrantor.id)
-                  : getSponsoredAmount2023(regrantor.id)
-              }
+              sponsoredAmount={getSponsoredAmount(regrantor.id, selectedYear)}
               profile={regrantor}
             />
           )

--- a/app/about/regranting/regrantors-display.tsx
+++ b/app/about/regranting/regrantors-display.tsx
@@ -1,0 +1,83 @@
+'use client'
+
+import { Row } from '@/components/layout/row'
+import { ProfileCard } from '@/components/profile-card'
+import { Profile } from '@/db/profile'
+import {
+  getSponsoredAmount2023,
+  getSponsoredAmount2024,
+} from '@/utils/constants'
+import clsx from 'clsx'
+import { sortBy } from 'lodash'
+import { useState } from 'react'
+
+export function RegrantorsDisplay(props: { regrantors: Profile[] }) {
+  const { regrantors } = props
+  const sortedRegrantors2023 = sortBy(
+    regrantors.filter((r) => getSponsoredAmount2023(r.id) !== 0),
+    [
+      function (regranter: Profile) {
+        return -getSponsoredAmount2023(regranter.id)
+      },
+    ]
+  )
+  const sortedRegrantors2024 = sortBy(
+    regrantors.filter((r) => getSponsoredAmount2024(r.id) !== 0),
+    [
+      function (regranter: Profile) {
+        return -getSponsoredAmount2024(regranter.id)
+      },
+    ]
+  )
+  const [selectedYear, setSelectedYear] = useState(2024)
+  const regrantorsToShow =
+    selectedYear === 2023 ? sortedRegrantors2023 : sortedRegrantors2024
+  return (
+    <div className="mt-5">
+      <Row className="justify-between">
+        <h3 className="mb-2 text-xl font-semibold text-gray-900">
+          Our regrantors
+        </h3>
+        <Row className="gap-3">
+          <button
+            onClick={() => setSelectedYear(2023)}
+            className={clsx(
+              'rounded-md px-3 py-2 text-sm font-medium',
+              selectedYear === 2023
+                ? 'bg-orange-100 text-orange-600'
+                : 'text-gray-500 hover:text-gray-700'
+            )}
+          >
+            2023
+          </button>
+          <button
+            onClick={() => setSelectedYear(2024)}
+            className={clsx(
+              'rounded-md px-3 py-2 text-sm font-medium',
+              selectedYear === 2024
+                ? 'bg-orange-100 text-orange-600'
+                : 'text-gray-500 hover:text-gray-700'
+            )}
+          >
+            2024
+          </button>
+        </Row>
+      </Row>
+      <div className="mx-auto mb-5 mt-2 grid grid-cols-2 gap-4 sm:grid-cols-3">
+        {regrantorsToShow.map((regrantor) => {
+          return (
+            <ProfileCard
+              key={regrantor.id}
+              sponsoredAmount={
+                selectedYear === 2024
+                  ? getSponsoredAmount2024(regrantor.id)
+                  : getSponsoredAmount2023(regrantor.id)
+              }
+              profile={regrantor}
+            />
+          )
+        })}
+      </div>
+    </div>
+  )
+}

--- a/app/create-grant/create-grant-form.tsx
+++ b/app/create-grant/create-grant-form.tsx
@@ -77,6 +77,7 @@ export function CreateGrantForm(props: {
   const [minFunding, setMinFunding] = useState<number>()
   const [selectedCauses, setSelectedCauses] = useState<MiniCause[]>([])
   const [locationDescription, setLocationDescription] = useState('')
+  const [lobbying, setLobbying] = useState(false)
   const [agreedToTerms, setAgreedToTerms] = useState(false)
   const [isSubmitting, setIsSubmitting] = useState(false)
   const descriptionEditor = useTextEditor(DESCRIPTION_OUTLINE, DESCRIPTION_KEY)
@@ -156,6 +157,8 @@ export function CreateGrantForm(props: {
       'The minimum funding must be greater than your contribution. Otherwise, indicate that the project does not need more funding.'
   } else if (maxDonation < donorContribution) {
     errorMessage = `You currently have $${maxDonation} to give. If you would like to give a larger grant, you can add money to your account or raise more funds from other users on Manifund.`
+  } else if (!locationDescription) {
+    errorMessage = 'Please enter the location description.'
   } else if (!agreedToTerms) {
     errorMessage =
       'Please confirm that you understand and agree to the terms of giving this grant.'
@@ -489,11 +492,13 @@ export function CreateGrantForm(props: {
         />
       </Col>
       <Col className="gap-1">
-        <label>International activities</label>
+        <label>
+          In what countries are the grantee and anyone else working on this
+          project located?
+          <RequiredStar />
+        </label>
         <p className="text-sm text-gray-600">
-          If any part of this project will happen outside of the US, or people
-          working on the project are not US residents, please describe what will
-          happen internationally and where. Only a sentence or two needed.
+          This is for Manifund operations and will not be published.
         </p>
         <Input
           type="text"
@@ -501,25 +506,29 @@ export function CreateGrantForm(props: {
           onChange={(event) => setLocationDescription(event.target.value)}
         />
       </Col>
-      <Row>
+      <Row className="items-start">
         <Checkbox
-          id="terms"
-          aria-describedby="terms-description"
-          name="terms"
-          checked={agreedToTerms}
-          onChange={() => setAgreedToTerms(!agreedToTerms)}
+          checked={lobbying}
+          onChange={(event) => setLobbying(event.target.checked)}
         />
-        <div className="ml-3 text-sm leading-6">
-          <label htmlFor="terms" className="font-medium text-gray-900">
-            Check this box to confirm:
-          </label>{' '}
-          <span id="terms-description" className="text-gray-500">
-            all information provided is true and accurate to the best of my
-            knowledge. This project is not part of a political campaign. I
-            understand that all of my answers here will be publicly accessible
-            on Manifund.
+        <span className="ml-3 mt-0.5 text-sm leading-tight">
+          <span className="font-bold">
+            This project will engage in{' '}
+            <a
+              href="https://www.irs.gov/charities-non-profits/lobbying"
+              className="text-orange-600 hover:underline"
+            >
+              lobbying
+            </a>
+            .
           </span>
-        </div>
+          <span>
+            {' '}
+            Check this box if this project will involve any lobbying activities,
+            in the US or internationally.
+          </span>
+          <RequiredStar />
+        </span>
       </Row>
       <Tooltip text={errorMessage}>
         <Button

--- a/app/create-grant/create-grant-form.tsx
+++ b/app/create-grant/create-grant-form.tsx
@@ -17,7 +17,7 @@ import { RequiredStar } from '@/components/tags'
 import { clearLocalStorageItem } from '@/hooks/use-local-storage'
 import { Tooltip } from '@/components/tooltip'
 import { SelectCauses } from '@/components/select-causes'
-import { MiniCause } from '@/db/cause'
+import { MiniCause, SimpleCause } from '@/db/cause'
 import { isEmailValid } from '@/utils/parse'
 
 const DESCRIPTION_OUTLINE = `
@@ -51,7 +51,7 @@ const REASONING_KEY = 'GrantReasoning'
 
 export function CreateGrantForm(props: {
   profiles: MiniProfile[]
-  causesList: MiniCause[]
+  causesList: SimpleCause[]
   maxDonation: number
 }) {
   const { profiles, maxDonation, causesList } = props
@@ -83,6 +83,10 @@ export function CreateGrantForm(props: {
   const descriptionEditor = useTextEditor(DESCRIPTION_OUTLINE, DESCRIPTION_KEY)
   const reasoningEditor = useTextEditor(REASONING_OUTLINE, REASONING_KEY)
   const router = useRouter()
+
+  const selectableCauses = causesList.filter(
+    (cause) => cause.open && !cause.prize
+  )
 
   const fundingOptions = {
     fullyFund: 'be fully funded',
@@ -190,6 +194,7 @@ export function CreateGrantForm(props: {
           : undefined,
         causeSlugs: selectedCauses.map((cause) => cause.slug),
         locationDescription,
+        lobbying,
       }),
     })
     const newProject = await response.json()
@@ -486,7 +491,7 @@ export function CreateGrantForm(props: {
       <Col className="gap-1">
         <label>Cause areas</label>
         <SelectCauses
-          causesList={causesList}
+          causesList={selectableCauses}
           selectedCauses={selectedCauses}
           setSelectedCauses={setSelectedCauses}
         />

--- a/app/create-grant/create-grant-form.tsx
+++ b/app/create-grant/create-grant-form.tsx
@@ -78,7 +78,6 @@ export function CreateGrantForm(props: {
   const [selectedCauses, setSelectedCauses] = useState<MiniCause[]>([])
   const [locationDescription, setLocationDescription] = useState('')
   const [lobbying, setLobbying] = useState(false)
-  const [agreedToTerms, setAgreedToTerms] = useState(false)
   const [isSubmitting, setIsSubmitting] = useState(false)
   const descriptionEditor = useTextEditor(DESCRIPTION_OUTLINE, DESCRIPTION_KEY)
   const reasoningEditor = useTextEditor(REASONING_OUTLINE, REASONING_KEY)
@@ -163,9 +162,6 @@ export function CreateGrantForm(props: {
     errorMessage = `You currently have $${maxDonation} to give. If you would like to give a larger grant, you can add money to your account or raise more funds from other users on Manifund.`
   } else if (!locationDescription) {
     errorMessage = 'Please enter the location description.'
-  } else if (!agreedToTerms) {
-    errorMessage =
-      'Please confirm that you understand and agree to the terms of giving this grant.'
   } else {
     errorMessage = null
   }

--- a/app/create-grant/create-grant-form.tsx
+++ b/app/create-grant/create-grant-form.tsx
@@ -18,6 +18,7 @@ import { clearLocalStorageItem } from '@/hooks/use-local-storage'
 import { Tooltip } from '@/components/tooltip'
 import { SelectCauses } from '@/components/select-causes'
 import { MiniCause } from '@/db/cause'
+import { isEmailValid } from '@/utils/parse'
 
 const DESCRIPTION_OUTLINE = `
 <h3>Project summary</h3>
@@ -125,6 +126,8 @@ export function CreateGrantForm(props: {
     errorMessage = 'Please enter the name of the recipient.'
   } else if (!recipientOnManifund && !recipientEmail) {
     errorMessage = 'Please enter the email address of the recipient.'
+  } else if (!isEmailValid(recipientEmail)) {
+    errorMessage = 'Invalid recipient email address.'
   } else if (recipientOnManifund && recipient === null) {
     errorMessage = 'Please select the recipient.'
   } else if (!title) {
@@ -251,6 +254,8 @@ export function CreateGrantForm(props: {
             <Input
               type="text"
               id="recipientEmail"
+              error={!isEmailValid(recipientEmail) && recipientEmail !== ''}
+              errorMessage={'Invalid email'}
               value={recipientEmail}
               onChange={(event) => setRecipientEmail(event.target.value)}
             />

--- a/app/create-grant/page.tsx
+++ b/app/create-grant/page.tsx
@@ -7,7 +7,7 @@ import { getTxnAndProjectsByUser } from '@/db/txn'
 import { getBidsByUser } from '@/db/bid'
 import Link from 'next/link'
 import { calculateCharityBalance } from '@/utils/math'
-import { listMiniCauses } from '@/db/cause'
+import { listSimpleCauses } from '@/db/cause'
 
 export const revalidate = 60
 export default async function CreateGrantPage() {
@@ -30,7 +30,7 @@ export default async function CreateGrantPage() {
     getProfileById(supabase, user.id),
     getTxnAndProjectsByUser(supabase, user.id),
     getBidsByUser(supabase, user.id),
-    listMiniCauses(supabase),
+    listSimpleCauses(supabase),
   ])
   if (!profile?.regranter_status) {
     return (

--- a/app/people/people-display.tsx
+++ b/app/people/people-display.tsx
@@ -13,7 +13,7 @@ import {
   CurrencyDollarIcon,
   WrenchIcon,
 } from '@heroicons/react/20/solid'
-import { getSponsoredAmount } from '@/utils/constants'
+import { getSponsoredAmount2024 } from '@/utils/constants'
 import { SearchBar } from '@/components/input'
 import { searchInAny } from '@/utils/parse'
 import { LoadMoreUntilNotVisible } from '@/components/widgets/visibility-observer'
@@ -110,7 +110,7 @@ function ProfileRow(props: { profile: Profile; isCreator?: boolean }) {
 
 function sortProfiles(profiles: ProfileAndProjectTitles[]) {
   const sortedProfiles = sortBy(profiles, (profile) => {
-    if (profile.regranter_status) return -getSponsoredAmount(profile.id)
+    if (profile.regranter_status) return -getSponsoredAmount2024(profile.id)
     else if (profile.projects.length > 0) return 1
     else if (profile.bio) return 2
     else if (profile.accreditation_status) return 3

--- a/app/projects/page.tsx
+++ b/app/projects/page.tsx
@@ -46,6 +46,34 @@ export default async function Projects(props: {
     <Col className="gap-16 px-3 py-5 sm:px-6">
       {user === null && <LandingSection />}
       <Col className="gap-3">
+        <h3 className="text-2xl font-semibold">Active programs</h3>
+        <Link
+          className="relative flex flex-col gap-4 rounded-lg bg-white p-4 shadow-md sm:flex-row"
+          href="/about/regranting"
+        >
+          <Image
+            src={
+              'https://fkousziwzbnkdkldjper.supabase.co/storage/v1/object/public/round-header-images/regrants/getty-images-a3BzdnbjSSM-unsplash.jpg'
+            }
+            width={240}
+            height={120}
+            className="relative aspect-[3/1] w-full flex-shrink-0 rounded bg-white object-cover sm:aspect-[5/3] sm:w-60"
+            alt="round header image"
+          />
+          <Col className="w-full justify-between">
+            <Col className="mb-5 gap-2">
+              <p className="text-lg font-semibold leading-tight lg:text-xl">
+                Regranting
+              </p>
+              <span className="text-sm text-gray-600 sm:text-base">
+                We delegate grantmaking budgets to regrantors who are experts in
+                their fields, who then recommend grants based on their
+                expertise. We ran one round of regranting in H2 2023, and are
+                renewing the program for 2024!
+              </span>
+            </Col>
+          </Col>
+        </Link>
         {featuredCauses.map((cause) => (
           <CausePreview cause={cause} key={cause.slug} />
         ))}

--- a/app/rounds/[roundSlug]/round-tabs.tsx
+++ b/app/rounds/[roundSlug]/round-tabs.tsx
@@ -68,7 +68,13 @@ export function RoundTabs(props: {
           ) : (
             <div className="mt-2 grid grid-cols-2 gap-4 lg:grid-cols-3">
               {sortedRegranters.map((regranter) => {
-                return <ProfileCard key={regranter.id} profile={regranter} />
+                return (
+                  <ProfileCard
+                    key={regranter.id}
+                    sponsoredAmount={getSponsoredAmount2023(regranter.id)}
+                    profile={regranter}
+                  />
+                )
               })}
             </div>
           )}

--- a/app/rounds/[roundSlug]/round-tabs.tsx
+++ b/app/rounds/[roundSlug]/round-tabs.tsx
@@ -8,7 +8,7 @@ import { Profile } from '@/db/profile'
 import { FullProject } from '@/db/project'
 import { Round } from '@/db/round'
 import { SimpleCause } from '@/db/cause'
-import { getSponsoredAmount } from '@/utils/constants'
+import { getSponsoredAmount2023 } from '@/utils/constants'
 import { UserPlusIcon, WrenchIcon } from '@heroicons/react/20/solid'
 import { sortBy } from 'lodash'
 import { useSearchParams } from 'next/navigation'
@@ -50,7 +50,7 @@ export function RoundTabs(props: {
   if (round.title === 'Regrants' && regranters) {
     const sortedRegranters = sortBy(regranters, [
       function (regranter: Profile) {
-        return -getSponsoredAmount(regranter.id)
+        return -getSponsoredAmount2023(regranter.id)
       },
     ])
     tabs.push({

--- a/components/avatar.tsx
+++ b/components/avatar.tsx
@@ -44,7 +44,7 @@ export function Avatar(props: {
       alt={`${username ?? 'Unknown user'} avatar`}
     />
   ) : (
-    <div onClick={onClick} className={className}>
+    <div onClick={onClick} className={clsx(className, 'rounded-full')}>
       <GeneratedAvatar seed={id} size={s} aria-hidden="true" />
     </div>
   )

--- a/components/profile-card.tsx
+++ b/components/profile-card.tsx
@@ -7,35 +7,25 @@ import { Row } from './layout/row'
 import { Col } from './layout/col'
 import { addHttpToUrl, formatMoney } from '@/utils/formatting'
 import { LinkIcon } from '@heroicons/react/20/solid'
-import { getSponsoredAmount2023 } from '@/utils/constants'
+import {
+  getSponsoredAmount2023,
+  getSponsoredAmount2024,
+} from '@/utils/constants'
 import { SponsoredTag } from './tags'
 
 export function ProfileCard(props: { profile: Profile; className?: string }) {
   const { profile, className } = props
-  const sponsoredAmount = getSponsoredAmount2023(profile.id)
+  const sponsoredAmount2023 = getSponsoredAmount2023(profile.id)
+  const sponsoredAmount2024 = getSponsoredAmount2024(profile.id)
   return (
     <Card
       className={clsx(
-        'relative flex h-full flex-col gap-4 border-none py-6',
+        'relative flex h-full flex-col gap-4 border-none py-3',
         className
       )}
     >
-      {profile.website && (
-        <Link
-          href={addHttpToUrl(profile.website)}
-          className="absolute right-3 top-3"
-        >
-          <LinkIcon className="h-5 w-5 rounded bg-gray-300 p-0.5 text-white" />
-        </Link>
-      )}
-      {sponsoredAmount !== 0 && (
-        <SponsoredTag
-          text={`${formatMoney(sponsoredAmount)}`}
-          className="absolute left-3 top-3"
-        />
-      )}
       <Link href={`/${profile.username}`} className="flex h-full flex-col">
-        <Row className="mb-3 mt-5 justify-center">
+        <Row className="mb-3 mt-2 justify-center">
           <Avatar
             avatarUrl={profile.avatar_url}
             username={profile.username}
@@ -55,6 +45,28 @@ export function ProfileCard(props: { profile: Profile; className?: string }) {
           </Col>
         </Col>
       </Link>
+      <Row className="items-center justify-between">
+        <Row className="gap-1">
+          {sponsoredAmount2024 > 0 && (
+            <SponsoredTag
+              text={`${formatMoney(sponsoredAmount2024)}`}
+              active
+              className="absolute left-3 top-3"
+            />
+          )}
+          {sponsoredAmount2023 > 0 && (
+            <SponsoredTag
+              text={`${formatMoney(sponsoredAmount2023)}`}
+              className="absolute left-3 top-3"
+            />
+          )}
+        </Row>
+        {profile.website && (
+          <Link href={addHttpToUrl(profile.website)}>
+            <LinkIcon className="h-5 w-5 rounded bg-gray-100 stroke-2 p-1 text-gray-600 hover:bg-gray-200" />
+          </Link>
+        )}
+      </Row>
     </Card>
   )
 }

--- a/components/profile-card.tsx
+++ b/components/profile-card.tsx
@@ -7,12 +7,12 @@ import { Row } from './layout/row'
 import { Col } from './layout/col'
 import { addHttpToUrl, formatMoney } from '@/utils/formatting'
 import { LinkIcon } from '@heroicons/react/20/solid'
-import { getSponsoredAmount } from '@/utils/constants'
+import { getSponsoredAmount2023 } from '@/utils/constants'
 import { SponsoredTag } from './tags'
 
 export function ProfileCard(props: { profile: Profile; className?: string }) {
   const { profile, className } = props
-  const sponsoredAmount = getSponsoredAmount(profile.id)
+  const sponsoredAmount = getSponsoredAmount2023(profile.id)
   return (
     <Card
       className={clsx(
@@ -23,7 +23,7 @@ export function ProfileCard(props: { profile: Profile; className?: string }) {
       {profile.website && (
         <Link
           href={addHttpToUrl(profile.website)}
-          className="absolute top-3 right-3"
+          className="absolute right-3 top-3"
         >
           <LinkIcon className="h-5 w-5 rounded bg-gray-300 p-0.5 text-white" />
         </Link>
@@ -31,11 +31,11 @@ export function ProfileCard(props: { profile: Profile; className?: string }) {
       {sponsoredAmount !== 0 && (
         <SponsoredTag
           text={`${formatMoney(sponsoredAmount)}`}
-          className="absolute top-3 left-3"
+          className="absolute left-3 top-3"
         />
       )}
       <Link href={`/${profile.username}`} className="flex h-full flex-col">
-        <Row className="mt-5 mb-3 justify-center">
+        <Row className="mb-3 mt-5 justify-center">
           <Avatar
             avatarUrl={profile.avatar_url}
             username={profile.username}
@@ -49,7 +49,7 @@ export function ProfileCard(props: { profile: Profile; className?: string }) {
             {profile.full_name}
           </span>
           <Col className="h-full justify-center">
-            <span className="text-center text-sm font-light leading-tight text-gray-500 line-clamp-3">
+            <span className="line-clamp-3 text-center text-sm font-light leading-tight text-gray-500">
               {profile.bio}
             </span>
           </Col>
@@ -87,7 +87,7 @@ export function CardlessProfile(props: { profile: Profile }) {
           {profile.full_name}
         </h1>
         <Col className="h-full justify-center">
-          <span className="text-center text-sm font-normal leading-6 text-gray-600 line-clamp-3">
+          <span className="line-clamp-3 text-center text-sm font-normal leading-6 text-gray-600">
             {profile.bio}
           </span>
         </Col>

--- a/components/profile-card.tsx
+++ b/components/profile-card.tsx
@@ -25,7 +25,6 @@ export function ProfileCard(props: {
       <Row className="items-center justify-between">
         <SponsoredTag
           text={`${formatMoney(sponsoredAmount)}`}
-          active
           className="absolute left-3 top-3"
         />
         {profile.website && (

--- a/components/profile-card.tsx
+++ b/components/profile-card.tsx
@@ -7,16 +7,14 @@ import { Row } from './layout/row'
 import { Col } from './layout/col'
 import { addHttpToUrl, formatMoney } from '@/utils/formatting'
 import { LinkIcon } from '@heroicons/react/20/solid'
-import {
-  getSponsoredAmount2023,
-  getSponsoredAmount2024,
-} from '@/utils/constants'
 import { SponsoredTag } from './tags'
 
-export function ProfileCard(props: { profile: Profile; className?: string }) {
-  const { profile, className } = props
-  const sponsoredAmount2023 = getSponsoredAmount2023(profile.id)
-  const sponsoredAmount2024 = getSponsoredAmount2024(profile.id)
+export function ProfileCard(props: {
+  profile: Profile
+  sponsoredAmount: number
+  className?: string
+}) {
+  const { profile, sponsoredAmount, className } = props
   return (
     <Card
       className={clsx(
@@ -24,6 +22,18 @@ export function ProfileCard(props: { profile: Profile; className?: string }) {
         className
       )}
     >
+      <Row className="items-center justify-between">
+        <SponsoredTag
+          text={`${formatMoney(sponsoredAmount)}`}
+          active
+          className="absolute left-3 top-3"
+        />
+        {profile.website && (
+          <Link href={addHttpToUrl(profile.website)}>
+            <LinkIcon className="h-5 w-5 rounded bg-gray-100 stroke-2 p-1 text-gray-600 hover:bg-gray-200" />
+          </Link>
+        )}
+      </Row>
       <Link href={`/${profile.username}`} className="flex h-full flex-col">
         <Row className="mb-3 mt-2 justify-center">
           <Avatar
@@ -45,28 +55,6 @@ export function ProfileCard(props: { profile: Profile; className?: string }) {
           </Col>
         </Col>
       </Link>
-      <Row className="items-center justify-between">
-        <Row className="gap-1">
-          {sponsoredAmount2024 > 0 && (
-            <SponsoredTag
-              text={`${formatMoney(sponsoredAmount2024)}`}
-              active
-              className="absolute left-3 top-3"
-            />
-          )}
-          {sponsoredAmount2023 > 0 && (
-            <SponsoredTag
-              text={`${formatMoney(sponsoredAmount2023)}`}
-              className="absolute left-3 top-3"
-            />
-          )}
-        </Row>
-        {profile.website && (
-          <Link href={addHttpToUrl(profile.website)}>
-            <LinkIcon className="h-5 w-5 rounded bg-gray-100 stroke-2 p-1 text-gray-600 hover:bg-gray-200" />
-          </Link>
-        )}
-      </Row>
     </Card>
   )
 }

--- a/components/project-card.tsx
+++ b/components/project-card.tsx
@@ -18,9 +18,10 @@ import { UserAvatarAndBadge } from './user-link'
 import { Card } from './layout/card'
 import { Row } from './layout/row'
 import { Tooltip } from './tooltip'
-import { getSponsoredAmount } from '@/utils/constants'
-import { MiniCause } from '@/db/cause'
-import { pt } from 'date-fns/locale'
+import {
+  getSponsoredAmount2023,
+  getSponsoredAmount2024,
+} from '@/utils/constants'
 
 export function ProjectCard(props: {
   project: FullProject
@@ -32,7 +33,9 @@ export function ProjectCard(props: {
     project.stage === 'proposal'
       ? orderBy(project.bids, 'created_at', 'asc')[0]?.bidder
       : orderBy(project.txns, 'created_at', 'asc')[0]?.from_id
-  const regrantorInitiated = getSponsoredAmount(firstDonorId ?? '') > 0
+  const regrantorInitiated =
+    getSponsoredAmount2023(firstDonorId ?? '') > 0 ||
+    getSponsoredAmount2024(firstDonorId ?? '') > 0
   const voteCount = project.project_votes.reduce(
     (acc, vote) => vote.magnitude + acc,
     0

--- a/components/project-card.tsx
+++ b/components/project-card.tsx
@@ -18,10 +18,7 @@ import { UserAvatarAndBadge } from './user-link'
 import { Card } from './layout/card'
 import { Row } from './layout/row'
 import { Tooltip } from './tooltip'
-import {
-  getSponsoredAmount2023,
-  getSponsoredAmount2024,
-} from '@/utils/constants'
+import { getSponsoredAmount } from '@/utils/constants'
 
 export function ProjectCard(props: {
   project: FullProject
@@ -33,9 +30,7 @@ export function ProjectCard(props: {
     project.stage === 'proposal'
       ? orderBy(project.bids, 'created_at', 'asc')[0]?.bidder
       : orderBy(project.txns, 'created_at', 'asc')[0]?.from_id
-  const regrantorInitiated =
-    getSponsoredAmount2023(firstDonorId ?? '') > 0 ||
-    getSponsoredAmount2024(firstDonorId ?? '') > 0
+  const regrantorInitiated = getSponsoredAmount(firstDonorId ?? '') > 0
   const voteCount = project.project_votes.reduce(
     (acc, vote) => vote.magnitude + acc,
     0

--- a/components/tags.tsx
+++ b/components/tags.tsx
@@ -219,14 +219,16 @@ export function SponsoredTag(props: {
 }) {
   const { text, active, className } = props
   return (
-    <span
-      className={clsx(
-        'inline-flex items-center gap-x-1.5 rounded-md px-1.5 py-0.5 text-xs font-medium',
-        active ? 'bg-orange-100 text-orange-600' : 'bg-gray-100 text-gray-600'
-      )}
-    >
-      {text}
-    </span>
+    <Tooltip text={`Sponsored for ${text}`}>
+      <span
+        className={clsx(
+          'inline-flex items-center gap-x-1.5 rounded-md px-1.5 py-0.5 text-xs font-medium',
+          active ? 'bg-orange-100 text-orange-600' : 'bg-gray-100 text-gray-600'
+        )}
+      >
+        {text}
+      </span>
+    </Tooltip>
   )
 }
 

--- a/components/tags.tsx
+++ b/components/tags.tsx
@@ -212,27 +212,21 @@ export function Tag(props: {
   )
 }
 
-export function SponsoredTag(props: { text: string; className?: string }) {
-  const { text, className } = props
+export function SponsoredTag(props: {
+  text: string
+  active?: boolean
+  className?: string
+}) {
+  const { text, active, className } = props
   return (
-    <div className={clsx('rounded bg-orange-100 p-1', className)}>
-      <Tooltip text={`Sponsored by Manifund for ${text}`}>
-        <Row className="gap-0.5">
-          <Col className="justify-center text-sm font-medium text-orange-500">
-            <Image
-              className="h-4 w-4"
-              src="/SolidOrangeManifox.png"
-              alt="Manifox"
-              width={1000}
-              height={1000}
-            />
-          </Col>
-          <Col className="justify-center text-sm font-medium text-orange-500">
-            {text}
-          </Col>
-        </Row>
-      </Tooltip>
-    </div>
+    <span
+      className={clsx(
+        'inline-flex items-center gap-x-1.5 rounded-md px-1.5 py-0.5 text-xs font-medium',
+        active ? 'bg-orange-100 text-orange-600' : 'bg-gray-100 text-gray-600'
+      )}
+    >
+      {text}
+    </span>
   )
 }
 

--- a/components/tags.tsx
+++ b/components/tags.tsx
@@ -212,20 +212,11 @@ export function Tag(props: {
   )
 }
 
-export function SponsoredTag(props: {
-  text: string
-  active?: boolean
-  className?: string
-}) {
-  const { text, active, className } = props
+export function SponsoredTag(props: { text: string; className?: string }) {
+  const { text } = props
   return (
     <Tooltip text={`Sponsored for ${text}`}>
-      <span
-        className={clsx(
-          'inline-flex items-center gap-x-1.5 rounded-md px-1.5 py-0.5 text-xs font-medium',
-          active ? 'bg-orange-100 text-orange-600' : 'bg-gray-100 text-gray-600'
-        )}
-      >
+      <span className="inline-flex items-center gap-x-1.5 rounded-md bg-orange-100 px-1.5 py-0.5 text-xs font-medium text-orange-600">
         {text}
       </span>
     </Tooltip>

--- a/db/database.types.ts
+++ b/db/database.types.ts
@@ -992,6 +992,7 @@ export type Database = {
         round: string | null
         slug: string | null
         location_description: string | null
+        lobbying: boolean | null
       }
       transfer_row: {
         recipient_email: string | null

--- a/db/database.types.ts
+++ b/db/database.types.ts
@@ -958,6 +958,7 @@ export type Database = {
         | "mint cert"
         | "mana deposit"
         | "tip"
+        | "return bank funds"
     }
     CompositeTypes: {
       bid_row: {

--- a/pages/api/create-grant.ts
+++ b/pages/api/create-grant.ts
@@ -35,6 +35,7 @@ type GrantProps = {
   recipientUsername?: string
   causeSlugs: string[]
   locationDescription: string
+  lobbying: boolean
 }
 
 export default async function handler(req: NextRequest) {
@@ -51,6 +52,7 @@ export default async function handler(req: NextRequest) {
     recipientUsername,
     causeSlugs,
     locationDescription,
+    lobbying,
   } = (await req.json()) as GrantProps
   const supabase = createEdgeClient(req)
   const resp = await supabase.auth.getUser()
@@ -103,6 +105,7 @@ export default async function handler(req: NextRequest) {
     approved: null,
     signed_agreement: false,
     location_description: locationDescription,
+    lobbying,
   }
   if (recipientEmail && recipientName) {
     const donorComment = {

--- a/pages/api/transfer-money.ts
+++ b/pages/api/transfer-money.ts
@@ -95,11 +95,11 @@ export default async function handler(req: NextRequest) {
         donorName: donor.full_name,
         profileUrl: `${getURL()}/${regranterProfile.username}`,
       }
-      // await sendTemplateEmail(
-      //   TEMPLATE_IDS.REGRANTER_DONATION,
-      //   postmarkVars,
-      //   toId
-      // )
+      await sendTemplateEmail(
+        TEMPLATE_IDS.REGRANTER_DONATION,
+        postmarkVars,
+        toId
+      )
     }
   }
 

--- a/pages/api/transfer-money.ts
+++ b/pages/api/transfer-money.ts
@@ -95,11 +95,11 @@ export default async function handler(req: NextRequest) {
         donorName: donor.full_name,
         profileUrl: `${getURL()}/${regranterProfile.username}`,
       }
-      await sendTemplateEmail(
-        TEMPLATE_IDS.REGRANTER_DONATION,
-        postmarkVars,
-        toId
-      )
+      // await sendTemplateEmail(
+      //   TEMPLATE_IDS.REGRANTER_DONATION,
+      //   postmarkVars,
+      //   toId
+      // )
     }
   }
 

--- a/utils/constants.ts
+++ b/utils/constants.ts
@@ -76,6 +76,18 @@ export function getSponsoredAmount2024(regrantorId: string) {
   return sponsoredRegrantors[regrantorId] ?? 0
 }
 
+export function getSponsoredAmount(regrantorId: string, year?: number) {
+  if (year === 2023) {
+    return getSponsoredAmount2023(regrantorId)
+  } else if (year === 2024) {
+    return getSponsoredAmount2024(regrantorId)
+  } else {
+    return (
+      getSponsoredAmount2023(regrantorId) + getSponsoredAmount2024(regrantorId)
+    )
+  }
+}
+
 // Needed for people who are both accredited investors and regrantors
 const CHARITABLE_DEPOSITS = [
   '1e17c09d-aa7f-432a-b523-89691531b304', // $50k from Manifund Bank to Zvi

--- a/utils/constants.ts
+++ b/utils/constants.ts
@@ -42,7 +42,7 @@ export function getRoundTheme(roundTitle: string) {
   }
 }
 
-export function getSponsoredAmount(regrantorId: string) {
+export function getSponsoredAmount2023(regrantorId: string) {
   const sponsoredRegrantors = {
     'e083e3b0-a131-4eaa-8a83-6a146a196432': 50_000, // Isaak
     '4de2634d-3802-4141-881e-9ce687f87485': 50_000, // Rachel
@@ -55,11 +55,22 @@ export function getSponsoredAmount(regrantorId: string) {
     'e2a30cdd-6797-4e2c-8823-f051195fc77a': 50_000, // Ryan
     '232dc139-961a-4f9a-9ca5-0118b90287c0': 50_000, // Nuno
     'b11620f2-fdc7-414c-8a63-9ddee17ee669': 100_000, // Marcus
-    '1398ed62-4213-4923-a84e-a9931ae19492': 650_000, // Adam
-    '94a0c7b8-39fd-4856-a7e6-1f9429dbb4ad': 650_000, // Dan Hendrycks
+    '1398ed62-4213-4923-a84e-a9931ae19492': 400_000, // Adam
+    '94a0c7b8-39fd-4856-a7e6-1f9429dbb4ad': 400_000, // Dan Hendrycks
     'c0319265-58b4-40e3-821c-5d32a76cd650': 400_000, // Tristan
-    '647c9b3c-65ce-40cf-9464-ac02c741aacd': 700_000, // Evan
-    '75420de8-7e37-4971-bb29-9bfada0c453b': 650_000, // Leopold
+    '647c9b3c-65ce-40cf-9464-ac02c741aacd': 450_000, // Evan
+    '75420de8-7e37-4971-bb29-9bfada0c453b': 400_000, // Leopold
+  } as { [key: string]: number }
+  return sponsoredRegrantors[regrantorId] ?? 0
+}
+
+export function getSponsoredAmount2024(regrantorId: string) {
+  const sponsoredRegrantors = {
+    '1398ed62-4213-4923-a84e-a9931ae19492': 250_000, // Adam
+    '94a0c7b8-39fd-4856-a7e6-1f9429dbb4ad': 250_000, // Dan Hendrycks
+    '647c9b3c-65ce-40cf-9464-ac02c741aacd': 250_000, // Evan
+    '75420de8-7e37-4971-bb29-9bfada0c453b': 250_000, // Leopold
+    'e2a30cdd-6797-4e2c-8823-f051195fc77a': 250_000, // Ryan
     'e9362a95-cbec-4685-b179-91b4c5ba4edc': 250_000, // Neel Nanda
   } as { [key: string]: number }
   return sponsoredRegrantors[regrantorId] ?? 0

--- a/utils/math.ts
+++ b/utils/math.ts
@@ -279,7 +279,11 @@ export function getTxnCharityMultiplier(
   if (txn.type === 'project donation') {
     return isIncoming ? 0 : -1
   }
-  if (txn.type === 'profile donation' || txn.type === 'tip') {
+  if (
+    txn.type === 'profile donation' ||
+    txn.type === 'tip' ||
+    txn.type === 'return bank funds'
+  ) {
     return isIncoming ? 1 : -1
   }
   const isOwnProject = txn.projects?.creator === userId
@@ -308,7 +312,8 @@ export function getTxnCashMultiplier(
     txn.token !== 'USD' ||
     (txn.from_id !== userId && txn.to_id !== userId) ||
     txn.type === 'profile donation' ||
-    txn.type === 'tip'
+    txn.type === 'tip' ||
+    txn.type === 'return bank funds'
   ) {
     return 0
   }

--- a/utils/parse.ts
+++ b/utils/parse.ts
@@ -22,3 +22,11 @@ export function parseMentions(data: JSONContent): string[] {
   }
   return uniq(mentions)
 }
+
+export const isEmailValid = (email: string) => {
+  return email
+    .toLowerCase()
+    .match(
+      /^(([^<>()[\]\\.,;:\s@"]+(\.[^<>()[\]\\.,;:\s@"]+)*)|.(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/
+    )
+}


### PR DESCRIPTION
Set up for new regranting program! Changes include:
- preview on home page under "Active programs"
- toggle to display 2023 vs. 2024 regrantors on the about regranting page
- udpated the create grant form to: validate recipient emails, ask about lobbying, ask about location differently
I also cleared the balances of regrantors from last year, with a new txn type called "return bank funds" which pulls from the charity balance and doesn't display on the profile.

I have not yet added 2024 budgets, though that is easy to do whenever.