### PR TITLE
[draft] Consolidate admin client creation and checks

### DIFF
--- a/app/admin/approvals/page.tsx
+++ b/app/admin/approvals/page.tsx
@@ -1,4 +1,4 @@
-import { createAdminClient } from '@/pages/api/_db'
+import { createAuthorizedAdminClient } from '@/db/supabase-server-admin'
 import { GrantVerdict } from '../grant-verdict'
 import Link from 'next/link'
 import clsx from 'clsx'
@@ -7,7 +7,7 @@ import { Table } from '@/components/table-catalyst'
 export const revalidate = 300
 
 export default async function ApprovalsPage() {
-  const supabaseAdmin = createAdminClient()
+  const supabaseAdmin = await createAuthorizedAdminClient()
   // Instead of using listProjects, only fetch the fields out of the projects that we need
   const { data: projects } = await supabaseAdmin
     .from('projects')

--- a/app/admin/fix-avatars.tsx
+++ b/app/admin/fix-avatars.tsx
@@ -1,10 +1,10 @@
 'use client'
 import { Button } from '@/components/button'
-import { createAdminClient } from '@/pages/api/_db'
+import { createAuthorizedAdminClient } from '@/db/supabase-server-admin'
 import { SupabaseClient } from '@supabase/supabase-js'
 
-export function FixAvatars() {
-  const supabaseAdmin = createAdminClient()
+export async function FixAvatars() {
+  const supabaseAdmin = await createAuthorizedAdminClient()
   return (
     <Button
       onClick={async () => {

--- a/app/admin/layout.tsx
+++ b/app/admin/layout.tsx
@@ -3,7 +3,7 @@ import { createServerSupabaseClient } from '@/db/supabase-server'
 import NoAccess from '../no-access'
 import Link from 'next/link'
 import { Suspense } from 'react'
-import { createAdminClient } from '@/pages/api/_db'
+import { createAuthorizedAdminClient } from '@/db/supabase-server-admin'
 import { HomeIcon } from '@heroicons/react/24/outline'
 
 // Revalidate every 5 minutes
@@ -11,7 +11,7 @@ export const revalidate = 300
 
 // Separate components for each count to allow parallel loading
 async function UserCount() {
-  const supabase = createAdminClient()
+  const supabase = await createAuthorizedAdminClient()
   const { count } = await supabase
     .from('users')
     .select('*', { count: 'exact', head: true })
@@ -24,7 +24,7 @@ async function UserCount() {
 }
 
 async function TransactionCount() {
-  const supabase = createAdminClient()
+  const supabase = await createAuthorizedAdminClient()
   const { count } = await supabase
     .from('txns')
     .select('*', { count: 'exact', head: true })
@@ -38,7 +38,7 @@ async function TransactionCount() {
 }
 
 async function ProjectCount() {
-  const supabase = createAdminClient()
+  const supabase = await createAuthorizedAdminClient()
   const { count } = await supabase
     .from('projects')
     .select('*', { count: 'exact', head: true })

--- a/app/admin/projects/page.tsx
+++ b/app/admin/projects/page.tsx
@@ -1,4 +1,4 @@
-import { createAdminClient } from '@/pages/api/_db'
+import { createAuthorizedAdminClient } from '@/db/supabase-server-admin'
 import { listProjects } from '@/db/project'
 import { AddTags } from '../add-tags'
 import { ActivateProject } from '../activate-project'
@@ -9,7 +9,7 @@ import { Table } from '@/components/table-catalyst'
 export const revalidate = 300
 
 export default async function ProjectsPage() {
-  const supabaseAdmin = createAdminClient()
+  const supabaseAdmin = await createAuthorizedAdminClient()
   const projects = await listProjects(supabaseAdmin)
 
   return (

--- a/app/admin/tools/page.tsx
+++ b/app/admin/tools/page.tsx
@@ -1,10 +1,10 @@
-import { createAdminClient } from '@/pages/api/_db'
+import { createAuthorizedAdminClient } from '@/db/supabase-server-admin'
 import { RunScript } from '../run-script'
 import { Donations } from '../donations'
 import { RoundBidAmounts } from '../round-bid-amounts'
 
 export default async function ToolsPage() {
-  const supabaseAdmin = createAdminClient()
+  const supabaseAdmin = await createAuthorizedAdminClient()
   const { data: profiles } = await supabaseAdmin
     .from('profiles')
     .select('*')

--- a/app/admin/transactions/page.tsx
+++ b/app/admin/transactions/page.tsx
@@ -1,10 +1,10 @@
-import { createAdminClient } from '@/pages/api/_db'
 import { CreateTxn } from '../create-txn'
 import { Table } from '@/components/table-catalyst'
+import { createAuthorizedAdminClient } from '@/db/supabase-server-admin'
 
 export const revalidate = 300
 export default async function TransactionsPage() {
-  const supabaseAdmin = createAdminClient()
+  const supabaseAdmin = await createAuthorizedAdminClient()
   const { data: txns } = await supabaseAdmin
     .from('txns')
     .select(

--- a/app/admin/users/page.tsx
+++ b/app/admin/users/page.tsx
@@ -1,4 +1,4 @@
-import { createAdminClient } from '@/pages/api/_db'
+import { createAuthorizedAdminClient } from '@/db/supabase-server-admin'
 import { PayUser } from '../pay-user'
 import { VerifyInvestor } from '../verify-investor'
 import { DownloadTextButton } from '../download-text-button'
@@ -17,7 +17,7 @@ import {
 export const revalidate = 300
 
 export default async function UsersPage() {
-  const supabaseAdmin = createAdminClient()
+  const supabaseAdmin = await createAuthorizedAdminClient()
   const [{ data: users }, { data: profiles }, { data: txns }] =
     await Promise.all([
       supabaseAdmin.from('users').select('*'),

--- a/app/finances/page.tsx
+++ b/app/finances/page.tsx
@@ -1,9 +1,9 @@
-import { createAdminClient } from '@/pages/api/_db'
+import { createAuthorizedAdminClient } from '@/db/supabase-server-admin'
 import { userBalances } from '../admin/utils'
 import UsersGrid from './users-grid'
 
 export default async function FinancesPage() {
-  const supabase = createAdminClient()
+  const supabase = await createAuthorizedAdminClient()
   const [{ data: users }, { data: profiles }, { data: txns }] =
     await Promise.all([
       supabase.from('users').select('*'),

--- a/app/projects/[slug]/page.tsx
+++ b/app/projects/[slug]/page.tsx
@@ -5,7 +5,7 @@ import { getCommentsByProject } from '@/db/comment'
 import { getBidsByProject } from '@/db/bid'
 import { getTxnsByProject, getTxnAndProjectsByUser } from '@/db/txn'
 import { getUserEmail } from '@/utils/email'
-import { createAdminClient } from '@/pages/api/_db'
+import { createAuthorizedAdminClient } from '@/db/supabase-server-admin'
 import { ProjectDisplay } from './project-display'
 import { getPrizeCause, listSimpleCauses } from '@/db/cause'
 import { getBidsByUser } from '@/db/bid'
@@ -66,7 +66,7 @@ export default async function ProjectPage(props: { params: { slug: string } }) {
     supabase
   )
   const creatorEmail = userProfile?.regranter_status
-    ? await getUserEmail(createAdminClient(), project.creator)
+    ? await getUserEmail(await createAuthorizedAdminClient(), project.creator)
     : undefined
   const userIsAdmin = user ? isAdmin(user) : false
   const userIsOwner = user?.id === project.creator

--- a/db/supabase-server-admin.ts
+++ b/db/supabase-server-admin.ts
@@ -1,0 +1,18 @@
+import 'server-only'
+import { createClient } from '@supabase/supabase-js'
+import { Database } from '@/db/database.types'
+import { SUPABASE_SERVICE_ROLE_KEY, SUPABASE_URL } from '@/db/env'
+import { getUser, isAdmin } from './profile'
+import { createServerSupabaseClient } from './supabase-server'
+import { cache } from 'react'
+
+export const createAuthorizedAdminClient = cache(async () => {
+  const supabase = await createServerSupabaseClient()
+  const user = await getUser(supabase)
+
+  if (!user || !isAdmin(user)) {
+    throw new Error('Unauthorized: Admin access required')
+  }
+
+  return createClient<Database>(SUPABASE_URL!, SUPABASE_SERVICE_ROLE_KEY!)
+})

--- a/db/supabase-server.ts
+++ b/db/supabase-server.ts
@@ -2,15 +2,10 @@ import 'server-only'
 
 import { cookies } from 'next/headers'
 import { createServerClient } from '@supabase/ssr'
-import { createClient } from '@supabase/supabase-js'
 import { NextRequest, NextResponse } from 'next/server'
 
 import type { Database } from './database.types'
-import {
-  SUPABASE_ANON_KEY,
-  SUPABASE_URL,
-  SUPABASE_SERVICE_ROLE_KEY,
-} from './env'
+import { SUPABASE_ANON_KEY, SUPABASE_URL } from '@/db/env'
 
 // For Server Components, API Routes, and general server-side usage
 export const createServerSupabaseClient = async () => {
@@ -56,9 +51,4 @@ export function createMiddlewareSupabaseClient(
       },
     },
   })
-}
-
-// For admin operations that need elevated privileges
-export function createAdminSupabaseClient() {
-  return createClient<Database>(SUPABASE_URL!, SUPABASE_SERVICE_ROLE_KEY!)
 }

--- a/db/txn.ts
+++ b/db/txn.ts
@@ -1,5 +1,5 @@
 import { Database } from '@/db/database.types'
-import { SupabaseClient, User } from '@supabase/supabase-js'
+import { SupabaseClient } from '@supabase/supabase-js'
 import { Profile } from './profile'
 import { Project } from './project'
 
@@ -8,11 +8,6 @@ export type TxnAndProject = Txn & { projects?: Project }
 export type FullTxn = Txn & { projects?: Project } & { profiles?: Profile }
 export type TxnAndProfiles = Txn & { profiles?: Profile }
 export type TxnType = Database['public']['Tables']['txns']['Row']['type']
-
-export function isAdmin(user: User | null) {
-  const ADMINS = ['rachel.weinberg12@gmail.com', 'akrolsmir@gmail.com']
-  return ADMINS.includes(user?.email ?? '')
-}
 
 export async function getFullTxnsByUser(
   supabase: SupabaseClient,

--- a/pages/api/_db.ts
+++ b/pages/api/_db.ts
@@ -1,12 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server'
-import { createClient } from '@supabase/supabase-js'
 import { createServerClient } from '@supabase/ssr'
 import { Database } from '@/db/database.types'
-import {
-  SUPABASE_ANON_KEY,
-  SUPABASE_SERVICE_ROLE_KEY,
-  SUPABASE_URL,
-} from '@/db/env'
+import { SUPABASE_ANON_KEY, SUPABASE_URL } from '@/db/env'
 
 export function createEdgeClient(req: NextRequest) {
   const res = NextResponse.next()
@@ -23,11 +18,4 @@ export function createEdgeClient(req: NextRequest) {
       },
     },
   })
-}
-
-export function createAdminClient() {
-  return createClient<Database>(
-    SUPABASE_URL ?? '',
-    SUPABASE_SERVICE_ROLE_KEY ?? ''
-  )
 }

--- a/pages/api/acx-certs-email-script.ts
+++ b/pages/api/acx-certs-email-script.ts
@@ -1,4 +1,4 @@
-import { createAdminClient } from './_db'
+import { createAuthorizedAdminClient } from '@/db/supabase-server-admin'
 import { getIncompleteTransfers } from '@/db/project-transfer'
 import { SupabaseClient } from '@supabase/supabase-js'
 import { sendTemplateEmail, TEMPLATE_IDS } from '@/utils/email'
@@ -12,7 +12,7 @@ export const config = {
 }
 
 export default async function handler() {
-  const supabase = createAdminClient()
+  const supabase = await createAuthorizedAdminClient()
   const transfers = await getIncompleteTransfers(supabase)
   const acxCertTransfers = transfers.filter(
     (transfer) =>

--- a/pages/api/acx-grants-email-script.ts
+++ b/pages/api/acx-grants-email-script.ts
@@ -1,4 +1,4 @@
-import { createAdminClient } from './_db'
+import { createAuthorizedAdminClient } from '@/db/supabase-server-admin'
 import { getIncompleteTransfers } from '@/db/project-transfer'
 import { SupabaseClient } from '@supabase/supabase-js'
 import { sendTemplateEmail, TEMPLATE_IDS } from '@/utils/email'
@@ -13,7 +13,7 @@ export const config = {
 }
 
 export default async function handler() {
-  const supabase = createAdminClient()
+  const supabase = await createAuthorizedAdminClient()
   const transfersWithProjects = await getIncompleteTransfers(supabase)
   for (const transfer of transfersWithProjects) {
     console.log('TRANSFERING PROJECT: ', transfer.projects.title)

--- a/pages/api/add-all-followers.ts
+++ b/pages/api/add-all-followers.ts
@@ -1,6 +1,6 @@
 import { listProjects } from '@/db/project'
 import { uniq } from 'lodash'
-import { createAdminClient } from './_db'
+import { createAuthorizedAdminClient } from '@/db/supabase-server-admin'
 
 export const config = {
   runtime: 'edge',
@@ -11,7 +11,7 @@ export const config = {
 }
 
 export default async function handler() {
-  const supabase = createAdminClient()
+  const supabase = await createAuthorizedAdminClient()
   const projects = await listProjects(supabase)
   for (const project of projects) {
     const followerIds = []

--- a/pages/api/backfill-grant-agreements.ts
+++ b/pages/api/backfill-grant-agreements.ts
@@ -1,6 +1,6 @@
 import { FullProject } from '@/db/project'
 import { isBefore } from 'date-fns'
-import { createAdminClient } from './_db'
+import { createAuthorizedAdminClient } from '@/db/supabase-server-admin'
 import { sortBy } from 'lodash'
 import { SupabaseClient } from '@supabase/supabase-js'
 import { NextResponse } from 'next/server'
@@ -14,7 +14,7 @@ export const config = {
 }
 
 export default async function handler() {
-  const supabase = createAdminClient()
+  const supabase = await createAuthorizedAdminClient()
   const projects = await listProjectsForAgreements(supabase)
   const AUSTIN_PROFILE_ID = '10bd8a14-4002-47ff-af4a-92b227423a74'
   for (const project of projects) {

--- a/pages/api/categorize-txns.ts
+++ b/pages/api/categorize-txns.ts
@@ -2,7 +2,7 @@ import { Txn } from '@/db/txn'
 import { bundleTxns } from '@/utils/math'
 import { SupabaseClient } from '@supabase/supabase-js'
 import { NextResponse } from 'next/server'
-import { createAdminClient } from './_db'
+import { createAuthorizedAdminClient } from '@/db/supabase-server-admin'
 
 export const config = {
   runtime: 'edge',
@@ -15,7 +15,7 @@ export const config = {
 
 // Used to add txn type column to txns table
 export default async function handler() {
-  const supabaseAdmin = createAdminClient()
+  const supabaseAdmin = await createAuthorizedAdminClient()
   const { data: txns } = await supabaseAdmin.from('txns').select('*')
   await dbCategorizeTxns(txns ?? [], supabaseAdmin)
   return NextResponse.json('success')

--- a/pages/api/change-acx-close-dates.ts
+++ b/pages/api/change-acx-close-dates.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from 'next/server'
-import { createAdminClient } from './_db'
+import { createAuthorizedAdminClient } from '@/db/supabase-server-admin'
 
 export const config = {
   runtime: 'edge',
@@ -12,7 +12,7 @@ export const config = {
 
 // Used to add txn type column to txns table
 export default async function handler() {
-  const supabase = createAdminClient()
+  const supabase = await createAuthorizedAdminClient()
   const { error } = await supabase
     .from('projects')
     .update({ auction_close: '2024-04-05' })

--- a/pages/api/close-chinatalk.ts
+++ b/pages/api/close-chinatalk.ts
@@ -1,4 +1,4 @@
-import { createAdminClient } from './_db'
+import { createAuthorizedAdminClient } from '@/db/supabase-server-admin'
 
 export const config = {
   runtime: 'edge',
@@ -9,7 +9,7 @@ export const config = {
 }
 
 export default async function handler() {
-  const supabase = createAdminClient()
+  const supabase = await createAuthorizedAdminClient()
   await supabase
     .from('projects')
     .update({ stage: 'complete' })

--- a/pages/api/close-grants.ts
+++ b/pages/api/close-grants.ts
@@ -1,6 +1,6 @@
-import { differenceInDays, isBefore } from 'date-fns'
+import { differenceInDays } from 'date-fns'
 import { NextResponse } from 'next/server'
-import { createAdminClient } from './_db'
+import { createAuthorizedAdminClient } from '@/db/supabase-server-admin'
 import { getAmountRaised, getMinIncludingAmm } from '@/utils/math'
 import { Project } from '@/db/project'
 import { Bid } from '@/db/bid'
@@ -24,7 +24,7 @@ export default async function handler() {
   if (!isProd()) {
     return NextResponse.json('not prod')
   }
-  const supabase = createAdminClient()
+  const supabase = await createAuthorizedAdminClient()
   const { data: proposals, error } = await supabase
     .from('projects')
     .select(

--- a/pages/api/comment-notifications.ts
+++ b/pages/api/comment-notifications.ts
@@ -7,14 +7,14 @@ import { Comment } from '@/db/comment'
 import { JSONContent } from '@tiptap/core'
 import { TIPTAP_EXTENSIONS } from '@/components/editor'
 import { getProjectFollowerIds } from '@/db/follows'
-import { createAdminClient } from './_db'
+import { createAuthorizedAdminClient } from '@/db/supabase-server-admin'
 
 export default async function handler(
   req: NextApiRequest,
   res: NextApiResponse
 ) {
   const comment = req.body.record as Comment
-  const supabase = createAdminClient()
+  const supabase = await createAuthorizedAdminClient()
   const fullComment = await getCommentById(supabase, comment.id)
   const projectFollowerIds = await getProjectFollowerIds(
     supabase,

--- a/pages/api/create-project.ts
+++ b/pages/api/create-project.ts
@@ -1,7 +1,8 @@
 import { Project, TOTAL_SHARES } from '@/db/project'
 import { NextRequest, NextResponse } from 'next/server'
 import uuid from 'react-uuid'
-import { createAdminClient, createEdgeClient } from './_db'
+import { createAuthorizedAdminClient } from '@/db/supabase-server-admin'
+import { createEdgeClient } from './_db'
 import { projectSlugify, toTitleCase } from '@/utils/formatting'
 import { ProjectParams } from '@/utils/upsert-project'
 import { getPrizeCause, updateProjectCauses } from '@/db/cause'
@@ -106,7 +107,7 @@ export default async function handler(req: NextRequest) {
         type: project.stage === 'proposal' ? 'assurance sell' : 'sell',
       })
     } else if (certParams?.ammDollars && project.amm_shares) {
-      const supabaseAdmin = createAdminClient()
+      const supabaseAdmin = await createAuthorizedAdminClient()
       await supabaseAdmin.from('txns').insert({
         from_id: process.env.NEXT_PUBLIC_PROD_BANK_ID,
         to_id: user.id,

--- a/pages/api/edit-project.ts
+++ b/pages/api/edit-project.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { updateProjectCauses } from '@/db/cause'
-import { createAdminClient, createEdgeClient } from './_db'
+import { createAuthorizedAdminClient } from '@/db/supabase-server-admin'
+import { createEdgeClient } from './_db'
 import { ProjectUpdate, updateProject } from '@/db/project'
 import { isAdmin } from '@/db/txn'
 
@@ -22,7 +23,9 @@ export default async function handler(req: NextRequest) {
   const supabaseEdge = createEdgeClient(req)
   const resp = await supabaseEdge.auth.getUser()
   const user = resp.data.user
-  const supabase = isAdmin(user) ? createAdminClient() : supabaseEdge
+  const supabase = isAdmin(user)
+    ? await createAuthorizedAdminClient()
+    : supabaseEdge
   if (!user) return NextResponse.error()
   await updateProject(supabase, projectId, projectUpdate)
   console.log(causeSlugs)

--- a/pages/api/email-mcf-creator.ts
+++ b/pages/api/email-mcf-creator.ts
@@ -1,4 +1,4 @@
-import { createAdminClient } from './_db'
+import { createAuthorizedAdminClient } from '@/db/supabase-server-admin'
 import { getIncompleteTransfers } from '@/db/project-transfer'
 import { SupabaseClient } from '@supabase/supabase-js'
 import { sendTemplateEmail, TEMPLATE_IDS } from '@/utils/email'
@@ -14,7 +14,7 @@ export const config = {
 }
 
 export default async function handler() {
-  const supabase = createAdminClient()
+  const supabase = await createAuthorizedAdminClient()
   const { data: mcfProjects } = await supabase
     .from('projects')
     .select('creator, title, slug, stage')

--- a/pages/api/fix-txn-type-labels.ts
+++ b/pages/api/fix-txn-type-labels.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from 'next/server'
-import { createAdminClient } from './_db'
+import { createAuthorizedAdminClient } from '@/db/supabase-server-admin'
 
 export const config = {
   runtime: 'edge',
@@ -11,7 +11,7 @@ export const config = {
 }
 
 export default async function handler() {
-  const supabaseAdmin = createAdminClient()
+  const supabaseAdmin = await createAuthorizedAdminClient()
   await supabaseAdmin
     .from('txns')
     .update({ type: 'deposit' })

--- a/pages/api/fix-unupdated-agreements.ts
+++ b/pages/api/fix-unupdated-agreements.ts
@@ -1,5 +1,5 @@
 import { ProjectAndProfile } from '@/db/project'
-import { createAdminClient } from './_db'
+import { createAuthorizedAdminClient } from '@/db/supabase-server-admin'
 import { SupabaseClient } from '@supabase/supabase-js'
 import { NextResponse } from 'next/server'
 import { GrantAgreement } from '@/db/grant_agreement'
@@ -13,7 +13,7 @@ export const config = {
 }
 
 export default async function handler() {
-  const supabase = createAdminClient()
+  const supabase = await createAuthorizedAdminClient()
   // Fix projects where they were signed but not recorded in the agreements table
   const projects = await listMismatchedProjects(supabase)
   console.log(projects?.length)

--- a/pages/api/handle-new-bid.ts
+++ b/pages/api/handle-new-bid.ts
@@ -9,7 +9,7 @@ import { Bid } from '@/db/bid'
 import { getShareholders } from '@/app/projects/[slug]/project-tabs'
 import { sendTemplateEmail, TEMPLATE_IDS } from '@/utils/email'
 import { SupabaseClient } from '@supabase/supabase-js'
-import { createAdminClient } from './_db'
+import { createAuthorizedAdminClient } from '@/db/supabase-server-admin'
 import { getTxnsByProject } from '@/db/txn'
 import { getProfileById } from '@/db/profile'
 import { makeTrade, updateBidFromTrade } from '@/utils/trade'
@@ -19,7 +19,7 @@ export default async function handler(
   res: NextApiResponse
 ) {
   const bid = req.body.record as Bid
-  const supabase = createAdminClient()
+  const supabase = await createAuthorizedAdminClient()
   const project = await getProjectAndProfileById(supabase, bid.project)
   if (!project) {
     return res.status(404).json({ error: 'Project not found' })

--- a/pages/api/issue-grant-verdict.ts
+++ b/pages/api/issue-grant-verdict.ts
@@ -1,6 +1,7 @@
 import { JSONContent } from '@tiptap/react'
 import { NextRequest, NextResponse } from 'next/server'
-import { createAdminClient, createEdgeClient } from './_db'
+import { createAuthorizedAdminClient } from '@/db/supabase-server-admin'
+import { createEdgeClient } from './_db'
 import { getUser, isAdmin } from '@/db/profile'
 import { getProjectById } from '@/db/project'
 import { getAdminName, getURL } from '@/utils/constants'
@@ -40,7 +41,7 @@ export default async function handler(req: NextRequest) {
     return NextResponse.error()
   }
 
-  const supabaseAdmin = createAdminClient()
+  const supabaseAdmin = await createAuthorizedAdminClient()
   const { error } = await supabaseAdmin.rpc('execute_grant_verdict', {
     approved: approved,
     project_id: projectId,

--- a/pages/api/list-users.ts
+++ b/pages/api/list-users.ts
@@ -1,6 +1,7 @@
 import { getUser, isAdmin } from '@/db/profile'
 import { NextRequest, NextResponse } from 'next/server'
-import { createAdminClient, createEdgeClient } from './_db'
+import { createAuthorizedAdminClient } from '@/db/supabase-server-admin'
+import { createEdgeClient } from './_db'
 
 export const config = {
   runtime: 'edge',
@@ -12,7 +13,7 @@ export default async function handler(req: NextRequest) {
   const user = await getUser(supabaseEdge)
   if (!user || !isAdmin(user)) return Response.error()
 
-  const supabaseAdmin = createAdminClient()
+  const supabaseAdmin = await createAuthorizedAdminClient()
   const { data: users, error } = await supabaseAdmin.from('users').select('*')
   if (error) return Response.error()
 

--- a/pages/api/pay-user.ts
+++ b/pages/api/pay-user.ts
@@ -3,7 +3,8 @@ import { getProfileById, getUser, isAdmin } from '@/db/profile'
 import { getUserEmail, sendTemplateEmail, TEMPLATE_IDS } from '@/utils/email'
 import { NextRequest, NextResponse } from 'next/server'
 import uuid from 'react-uuid'
-import { createAdminClient, createEdgeClient } from './_db'
+import { createAuthorizedAdminClient } from '@/db/supabase-server-admin'
+import { createEdgeClient } from './_db'
 
 export const config = {
   runtime: 'edge',
@@ -24,7 +25,7 @@ export default async function handler(req: NextRequest) {
   const to_id =
     amount > 0 ? userId : (process.env.NEXT_PUBLIC_PROD_BANK_ID as string)
 
-  const supabaseAdmin = createAdminClient()
+  const supabaseAdmin = await createAuthorizedAdminClient()
   // Create a new txn paying this user
   const txnId = uuid()
   const { data: txn } = await supabaseAdmin

--- a/pages/api/publish-project.ts
+++ b/pages/api/publish-project.ts
@@ -1,6 +1,7 @@
 import { updateProject, getProjectById } from '@/db/project'
 import { NextRequest, NextResponse } from 'next/server'
-import { createAdminClient, createEdgeClient } from './_db'
+import { createAuthorizedAdminClient } from '@/db/supabase-server-admin'
+import { createEdgeClient } from './_db'
 import { createUpdateFromParams, ProjectParams } from '@/utils/upsert-project'
 import { getPrizeCause } from '@/db/cause'
 import { getProposalValuation, getMinIncludingAmm } from '@/utils/math'
@@ -50,7 +51,7 @@ export default async function handler(req: NextRequest) {
         type: startingStage === 'proposal' ? 'assurance sell' : 'sell',
       })
     } else if (certParams?.ammDollars && updatedProject.amm_shares) {
-      const supabaseAdmin = createAdminClient()
+      const supabaseAdmin = await createAuthorizedAdminClient()
       const { error } = await supabaseAdmin.from('txns').insert({
         from_id: process.env.NEXT_PUBLIC_PROD_BANK_ID,
         to_id: user.id,

--- a/pages/api/request-updates.ts
+++ b/pages/api/request-updates.ts
@@ -1,6 +1,6 @@
 import { differenceInMonths } from 'date-fns'
 import { NextResponse } from 'next/server'
-import { createAdminClient } from './_db'
+import { createAuthorizedAdminClient } from '@/db/supabase-server-admin'
 import { sendTemplateEmail, TEMPLATE_IDS } from '@/utils/email'
 import { isProd } from '@/db/env'
 import { orderBy } from 'lodash'
@@ -17,7 +17,7 @@ export default async function handler() {
   if (!isProd()) {
     return NextResponse.json('not prod')
   }
-  const supabase = createAdminClient()
+  const supabase = await createAuthorizedAdminClient()
   const { data: activeProjects, error } = await supabase
     .from('projects')
     .select(

--- a/pages/api/return-amm-assets.ts
+++ b/pages/api/return-amm-assets.ts
@@ -1,7 +1,7 @@
 import { Txn, TxnType } from '@/db/txn'
 import { SupabaseClient } from '@supabase/supabase-js'
 import { NextResponse } from 'next/server'
-import { createAdminClient } from './_db'
+import { createAuthorizedAdminClient } from '@/db/supabase-server-admin'
 import { Project } from '@/db/project'
 import { calculateAMMPorfolio } from '@/utils/amm'
 import uuid from 'react-uuid'
@@ -17,7 +17,7 @@ export const config = {
 
 // Used to add txn type column to txns table
 export default async function handler() {
-  const supabaseAdmin = createAdminClient()
+  const supabaseAdmin = await createAuthorizedAdminClient()
   const projects = await getProjectsByRound(
     supabaseAdmin,
     'Manifold Community Fund'

--- a/pages/api/stripe-endpoints.ts
+++ b/pages/api/stripe-endpoints.ts
@@ -1,6 +1,6 @@
 import Stripe from 'stripe'
 import { STRIPE_SECRET_KEY } from '@/db/env'
-import { createAdminClient } from './_db'
+import { createAuthorizedAdminClient } from '@/db/supabase-server-admin'
 import { sendTemplateEmail, TEMPLATE_IDS } from '@/utils/email'
 import { NextApiRequest, NextApiResponse } from 'next'
 import { Readable } from 'node:stream'
@@ -54,7 +54,7 @@ export default async function handler(
 
   if (event.type === 'checkout.session.completed') {
     const session = event.data.object as Stripe.Checkout.Session
-    const supabase = createAdminClient()
+    const supabase = await createAuthorizedAdminClient()
     const txnId = uuid()
     await issueMoneys(session, txnId, supabase)
     await sendTemplateEmail(

--- a/pages/api/submit-role.ts
+++ b/pages/api/submit-role.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server'
-import { createEdgeClient, createAdminClient } from './_db'
+import { createAuthorizedAdminClient } from '@/db/supabase-server-admin'
+import { createEdgeClient } from './_db'
 
 export const config = {
   runtime: 'edge',
@@ -45,7 +46,7 @@ export default async function handler(req: NextRequest) {
   // Grant funds
   const totalAmount = (Object.values(roles).filter(Boolean).length + 1) * 100
 
-  const supabaseAdmin = createAdminClient()
+  const supabaseAdmin = await createAuthorizedAdminClient()
   await supabaseAdmin.from('txns').insert({
     from_id: process.env.NEXT_PUBLIC_PROD_BANK_ID,
     to_id: user?.id ?? '',

--- a/pages/api/trade-with-limit.ts
+++ b/pages/api/trade-with-limit.ts
@@ -2,7 +2,8 @@ import { NextRequest, NextResponse } from 'next/server'
 import { genTradeText, makeTrade, updateBidFromTrade } from '@/utils/trade'
 import { getTxnAndProjectsByUser } from '@/db/txn'
 import { getProfileById } from '@/db/profile'
-import { createAdminClient, createEdgeClient } from './_db'
+import { createAuthorizedAdminClient } from '@/db/supabase-server-admin'
+import { createEdgeClient } from './_db'
 import {
   calculateCashBalance,
   calculateCharityBalance,
@@ -29,7 +30,7 @@ export type TradeProps = {
 export default async function handler(req: NextRequest) {
   const { oldBidId, numDollarsInTrade } = (await req.json()) as TradeProps
   const supabase = createEdgeClient(req)
-  const supabaseAdmin = createAdminClient()
+  const supabaseAdmin = await createAuthorizedAdminClient()
   const resp = await supabase.auth.getUser()
   const user = resp.data.user
   if (!user) {

--- a/pages/api/transfer-money.ts
+++ b/pages/api/transfer-money.ts
@@ -1,6 +1,7 @@
 import { getProjectById } from '@/db/project'
 import { NextRequest, NextResponse } from 'next/server'
-import { createAdminClient, createEdgeClient } from './_db'
+import { createAuthorizedAdminClient } from '@/db/supabase-server-admin'
+import { createEdgeClient } from './_db'
 import { getProfileById } from '@/db/profile'
 import { getTxnAndProjectsByUser } from '@/db/txn'
 import { getPendingBidsByUser } from '@/db/bid'
@@ -55,7 +56,7 @@ export default async function handler(req: NextRequest) {
     console.error('not enough funds')
     return NextResponse.error()
   }
-  const supabaseAdmin = createAdminClient()
+  const supabaseAdmin = await createAuthorizedAdminClient()
   const { error } = await supabaseAdmin.from('txns').insert({
     from_id: fromId,
     to_id: toId,

--- a/pages/api/transfer-project.ts
+++ b/pages/api/transfer-project.ts
@@ -1,11 +1,11 @@
-import { createAdminClient } from './_db'
+import { createAuthorizedAdminClient } from '@/db/supabase-server-admin'
 import { NextApiRequest } from 'next'
 import { User } from '@supabase/supabase-js'
 import { getTransfersByEmail } from '@/db/project-transfer'
 
 export default async function handler(req: NextApiRequest) {
   const user = req.body.record as User
-  const supabaseAdmin = createAdminClient()
+  const supabaseAdmin = await createAuthorizedAdminClient()
   const projectTransfers = await getTransfersByEmail(
     supabaseAdmin,
     user.email ?? ''

--- a/pages/api/verify-investor.ts
+++ b/pages/api/verify-investor.ts
@@ -1,7 +1,8 @@
 import { VerifyInvestorProps } from '@/app/admin/verify-investor'
 import { getUser, isAdmin } from '@/db/profile'
 import { NextRequest, NextResponse } from 'next/server'
-import { createAdminClient, createEdgeClient } from './_db'
+import { createAuthorizedAdminClient } from '@/db/supabase-server-admin'
+import { createEdgeClient } from './_db'
 
 export const config = {
   runtime: 'edge',
@@ -15,7 +16,7 @@ export default async function handler(req: NextRequest) {
 
   const { userId, accredited } = (await req.json()) as VerifyInvestorProps
 
-  const supabaseAdmin = createAdminClient()
+  const supabaseAdmin = await createAuthorizedAdminClient()
   // Create a new txn paying this user
   const { data: txn, error } = await supabaseAdmin
     .from('profiles')

--- a/utils/activate-project.ts
+++ b/utils/activate-project.ts
@@ -7,7 +7,7 @@ import {
   TOTAL_SHARES,
 } from '@/db/project'
 import { getTxnsByProject } from '@/db/txn'
-import { createAdminClient } from '@/pages/api/_db'
+import { createAuthorizedAdminClient } from '@/db/supabase-server-admin'
 import { SupabaseClient } from '@supabase/supabase-js'
 import { differenceInDays, isBefore } from 'date-fns'
 import { uniq } from 'lodash'
@@ -84,7 +84,7 @@ export function checkReactivateEligible(project: Project, prizeCause?: Cause) {
 }
 
 async function activateProject(project: Project, followerIds: string[]) {
-  const supabase = createAdminClient()
+  const supabase = await createAuthorizedAdminClient()
   const creatorProfile = await getProfileById(supabase, project?.creator)
   if (!project || !creatorProfile) {
     console.error('project', project, 'creatorProfile', creatorProfile)

--- a/utils/email.ts
+++ b/utils/email.ts
@@ -1,4 +1,4 @@
-import { createAdminClient } from '@/pages/api/_db'
+import { createAuthorizedAdminClient } from '@/db/supabase-server-admin'
 import { SupabaseClient } from '@supabase/supabase-js'
 
 export const TEMPLATE_IDS = {
@@ -27,7 +27,7 @@ export async function sendTemplateEmail(
   toEmail?: string,
   fromEmail?: string
 ) {
-  const supabase = createAdminClient()
+  const supabase = await createAuthorizedAdminClient()
   if (!toEmail && !toId) {
     console.log('No email or user id provided')
     return

--- a/utils/resolve-auction.ts
+++ b/utils/resolve-auction.ts
@@ -1,6 +1,6 @@
 import { Database } from '@/db/database.types'
 import { SupabaseClient } from '@supabase/supabase-js'
-import { createAdminClient } from '@/pages/api/_db'
+import { createAuthorizedAdminClient } from '@/db/supabase-server-admin'
 import { Project, TOTAL_SHARES, updateProjectStage } from '@/db/project'
 import { getBidsForResolution, BidAndProfile } from '@/db/bid'
 import { formatMoney, formatPercent } from '@/utils/formatting'
@@ -13,7 +13,7 @@ export const preferredRegion = ['sfo1']
 type Bid = Database['public']['Tables']['bids']['Row']
 
 export async function resolveAuction(project: Project) {
-  const supabase = createAdminClient()
+  const supabase = await createAuthorizedAdminClient()
   const bids = await getBidsForResolution(supabase, project.id)
   let founderPortion = project.founder_shares / TOTAL_SHARES
   const resolution = calcAuctionResolution(


### PR DESCRIPTION
getting a admin-authorized supabase client now enforces:
- the session corresponds to a user that's an admin. previously, createAdminClient() could theoretically be called without authorization checks. i don't think this was actually happening anywhere
- you're server-side. this is not totally necessary for security purposes: keys would not get to clients because nextjs doesn't populate env vars that aren't prefixed with `NEXT_PUBLIC_`. but it prevents outright the silent-failures where a client-side component tries to get the admin supabase client and then just isn't authorized

and also moved all the repeated isAdmin functions into a single spot :) 