### PR TITLE
Improve listProjects by splitting up the db query

### DIFF
--- a/app/projects/page.tsx
+++ b/app/projects/page.tsx
@@ -1,6 +1,7 @@
 import { Suspense } from 'react'
 import { createServerSupabaseClient } from '@/db/supabase-server'
 import { listProjects } from '@/db/project'
+import { listProjectsCached } from '@/db/project-cached'
 import { getUser } from '@/db/profile'
 import { Col } from '@/components/layout/col'
 import { FeedTabs } from './feed-tabs'
@@ -11,8 +12,7 @@ import { listSimpleCauses, getSomeFullCauses } from '@/db/cause'
 import { LandingSection } from './landing-section'
 import { CausesSection } from './causes-section'
 
-// Make this a dynamic route that's revalidated every 24h
-export const revalidate = 86400 // 24 hours
+// Page is dynamic due to cookies(), but listProjects is cached for 30s
 
 export default async function Projects(props: {
   searchParams: { [key: string]: string | string[] | undefined }
@@ -73,7 +73,7 @@ async function AsyncFeedTabs({
   const supabase = await createServerSupabaseClient()
   const [projects, recentComments, recentDonations, recentBids, causesList] =
     await Promise.all([
-      shouldLoadProjects ? listProjects(supabase) : Promise.resolve([]),
+      shouldLoadProjects ? listProjectsCached() : Promise.resolve([]),
       getRecentFullComments(supabase, PAGE_SIZE, start),
       getRecentFullTxns(supabase, PAGE_SIZE, start),
       getRecentFullBids(supabase, PAGE_SIZE, start),

--- a/db/project-cached.ts
+++ b/db/project-cached.ts
@@ -1,0 +1,21 @@
+import { revalidateTag, unstable_cache } from 'next/cache'
+import { listProjects } from './project'
+import { createPublicSupabaseClient } from './supabase-server'
+
+// Cached version of listProjects for public pages
+export const listProjectsCached = unstable_cache(
+  // eslint-disable-next-line @typescript-eslint/require-await
+  async () => {
+    const supabase = createPublicSupabaseClient()
+    return listProjects(supabase)
+  },
+  ['list-projects'], // cache key
+  {
+    revalidate: 30, // in seconds
+    tags: ['projects'], // for invalidation
+  }
+)
+
+export function invalidateProjectsCache() {
+  revalidateTag('projects')
+}

--- a/db/project.ts
+++ b/db/project.ts
@@ -184,7 +184,6 @@ export async function listProjects(supabase: SupabaseClient) {
   return Array.from(projectsMap.values()) as FullProject[]
 }
 
-
 export async function listProjectsForEvals(supabase: SupabaseClient) {
   const { data } = await supabase
     .from('projects')

--- a/db/supabase-server.ts
+++ b/db/supabase-server.ts
@@ -36,6 +36,18 @@ export const createServerSupabaseClient = async () => {
   })
 }
 
+// for cached functions and other contexts where cookies aren't needed
+export function createPublicSupabaseClient() {
+  return createServerClient<Database>(SUPABASE_URL!, SUPABASE_ANON_KEY!, {
+    cookies: {
+      getAll() {
+        return []
+      },
+      setAll() {},
+    },
+  })
+}
+
 // For Middleware and Edge API routes that have access to NextRequest/NextResponse
 export function createMiddlewareSupabaseClient(
   req: NextRequest,

--- a/pages/api/close-active-project.ts
+++ b/pages/api/close-active-project.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { createEdgeClient } from './_db'
+import { invalidateProjectsCache } from '@/db/project-cached'
 import { getProjectById, updateProjectStage } from '@/db/project'
 import { JSONContent } from '@tiptap/core'
 import { sendComment } from '@/db/comment'
@@ -34,5 +35,8 @@ export default async function handler(req: NextRequest) {
     undefined,
     'final report'
   )
+
+  invalidateProjectsCache()
+
   return NextResponse.json('success')
 }

--- a/pages/api/create-grant.ts
+++ b/pages/api/create-grant.ts
@@ -10,6 +10,7 @@ import { sendTemplateEmail, TEMPLATE_IDS } from '@/utils/email'
 import { JSONContent } from '@tiptap/react'
 import { calculateCharityBalance } from '@/utils/math'
 import { getTxnAndProjectsByUser } from '@/db/txn'
+import { invalidateProjectsCache } from '@/db/project-cached'
 import { getBidsByUser } from '@/db/bid'
 import { updateProjectCauses } from '@/db/cause'
 
@@ -175,5 +176,8 @@ export default async function handler(req: NextRequest) {
     return NextResponse.error()
   }
   await updateProjectCauses(supabase, causeSlugs, project.id)
+
+  invalidateProjectsCache()
+
   return NextResponse.json(project)
 }

--- a/pages/api/create-project.ts
+++ b/pages/api/create-project.ts
@@ -7,6 +7,7 @@ import { ProjectParams } from '@/utils/upsert-project'
 import { getPrizeCause, updateProjectCauses } from '@/db/cause'
 import { getProposalValuation, getMinIncludingAmm } from '@/utils/math'
 import { insertBid } from '@/db/bid'
+import { invalidateProjectsCache } from '@/db/project-cached'
 import { seedAmm } from '@/utils/activate-project'
 import { upvoteOwnProject, giveCreatorShares } from '@/utils/upsert-project'
 
@@ -118,5 +119,8 @@ export default async function handler(req: NextRequest) {
       await seedAmm(project, supabaseAdmin, certParams.ammDollars)
     }
   }
+
+  invalidateProjectsCache()
+
   return NextResponse.json(project)
 }

--- a/pages/api/edit-project.ts
+++ b/pages/api/edit-project.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server'
+import { invalidateProjectsCache } from '@/db/project-cached'
 import { updateProjectCauses } from '@/db/cause'
 import { createAdminClient, createEdgeClient } from './_db'
 import { ProjectUpdate, updateProject } from '@/db/project'
@@ -27,5 +28,8 @@ export default async function handler(req: NextRequest) {
   await updateProject(supabase, projectId, projectUpdate)
   console.log(causeSlugs)
   await updateProjectCauses(supabase, causeSlugs, projectId)
+
+  invalidateProjectsCache()
+
   return NextResponse.json('success')
 }

--- a/pages/api/publish-project.ts
+++ b/pages/api/publish-project.ts
@@ -1,4 +1,5 @@
 import { updateProject, getProjectById } from '@/db/project'
+import { invalidateProjectsCache } from '@/db/project-cached'
 import { NextRequest, NextResponse } from 'next/server'
 import { createAdminClient, createEdgeClient } from './_db'
 import { createUpdateFromParams, ProjectParams } from '@/utils/upsert-project'
@@ -66,5 +67,8 @@ export default async function handler(req: NextRequest) {
       await seedAmm(updatedProject, supabaseAdmin, certParams.ammDollars)
     }
   }
+
+  invalidateProjectsCache()
+
   return NextResponse.json('success')
 }

--- a/pages/api/reactivate-project.ts
+++ b/pages/api/reactivate-project.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server'
+import { invalidateProjectsCache } from '@/db/project-cached'
 import { createEdgeClient } from './_db'
 import { getUser } from '@/db/profile'
 import { getProjectWithCausesById } from '@/db/project'
@@ -32,6 +33,9 @@ export default async function handler(req: NextRequest) {
     return Response.error()
   }
   await reactivateProject(supabase, projectId)
+
+  invalidateProjectsCache()
+
   return NextResponse.json('success')
 }
 


### PR DESCRIPTION
Previously, listProjects made one large query, joining against many tables.

This new version makes multiple queries, keeping each of them small, and aiming to parallelize queries where possible.

The existing version takes ~5s when it doesn't time out, but does time out (taking over 8s) ~30% of the time.
This new version takes ~2.2s on average and also has lower variance: p95 was 3.3s for me. So never hitting timeouts.

The multiple-smaller-query approach has the advantage that it requires less memory usage (per-query, certainly, but even across all calls) -- my read of the EXPLAIN ALAYZE was that previously, the multiple joins created a big cartesian product that only got filtered at the end, which had some exponential-with-#-joins behavior where the new thing is linear.