### PR TITLE
add vercel cron job to update embeddings every day

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -7,6 +7,10 @@
     {
       "path": "/api/request-updates",
       "schedule": "0 15 * * 1"
+    },
+    {
+      "path": "/api/embeddings/sync",
+      "schedule": "0 8 * * *"
     }
   ]
 }


### PR DESCRIPTION
should rarely matter -- only if for some reason a project was created and its embedding wasn't created