### PR TITLE
Optimize hot projects query with single-pass scoring and reuse listProjects

### DIFF
--- a/app/projects/page.tsx
+++ b/app/projects/page.tsx
@@ -8,6 +8,7 @@ import { getRecentFullTxns } from '@/db/txn'
 import { getRecentFullBids } from '@/db/bid'
 import { listSimpleCauses } from '@/db/cause'
 import { listProjects } from '@/db/project'
+import { getHotProjectsCached } from '@/db/project-cached'
 import { LandingSection } from './landing-section'
 
 // Page is dynamic due to cookies(), but listProjects is cached for 30s
@@ -35,7 +36,7 @@ export default async function Projects(props: {
             <AsyncFeedTabs
               searchParams={props.searchParams}
               userId={user?.id}
-              projectLimit={30}
+              useHotProjects={true}
             />
           </Suspense>
         }
@@ -43,7 +44,7 @@ export default async function Projects(props: {
         <AsyncFeedTabs
           searchParams={props.searchParams}
           userId={user?.id}
-          projectLimit={2000}
+          useHotProjects={false}
         />
       </Suspense>
     </Col>
@@ -54,11 +55,11 @@ export default async function Projects(props: {
 async function AsyncFeedTabs({
   searchParams,
   userId,
-  projectLimit,
+  useHotProjects,
 }: {
   searchParams: { [key: string]: string | string[] | undefined }
   userId?: string
-  projectLimit?: number
+  useHotProjects: boolean
 }) {
   const PAGE_SIZE = 20
   const page = parseInt(searchParams?.p as string) || 1
@@ -69,9 +70,17 @@ async function AsyncFeedTabs({
   const start = (page - 1) * PAGE_SIZE
 
   const supabase = await createServerSupabaseClient()
+  const loadProjects = async () => {
+    if (!shouldLoadProjects) return []
+    if (useHotProjects) {
+      return getHotProjectsCached()
+    }
+    return listProjects(supabase)
+  }
+
   const [projects, recentComments, recentDonations, recentBids, causesList] =
     await Promise.all([
-      shouldLoadProjects ? listProjects(supabase) : Promise.resolve([]),
+      loadProjects(),
       getRecentFullComments(supabase, PAGE_SIZE, start),
       getRecentFullTxns(supabase, PAGE_SIZE, start),
       getRecentFullBids(supabase, PAGE_SIZE, start),

--- a/db/project-cached.ts
+++ b/db/project-cached.ts
@@ -1,22 +1,20 @@
 import { revalidateTag, unstable_cache } from 'next/cache'
-import { listProjects } from './project'
 import { createPublicSupabaseClient } from './supabase-server'
+import { getHotProjects } from './project-hot'
 
-// Cached version of listProjects for public pages
-// TODO: this is too large for the cache, should use a different approach
-export const listProjectsCached = unstable_cache(
-  // eslint-disable-next-line require-await
+export const getHotProjectsCached = unstable_cache(
   async () => {
     const supabase = createPublicSupabaseClient()
-    return listProjects(supabase)
+    const result = await getHotProjects(supabase, 20)
+    return result
   },
-  ['list-projects'], // cache key
+  ['hot-projects'],
   {
-    revalidate: 30, // in seconds
-    tags: ['projects'], // for invalidation
+    revalidate: 3600, // 1 hr
+    tags: ['hot-projects'],  // cache key
   }
 )
 
 export function invalidateProjectsCache() {
-  revalidateTag('projects')
+  revalidateTag('hot-projects')
 }

--- a/db/project-hot.ts
+++ b/db/project-hot.ts
@@ -1,0 +1,80 @@
+import { SupabaseClient } from '@supabase/supabase-js'
+import { FullProject, listProjects } from './project'
+import { hotScore } from '@/utils/sort'
+
+export async function getHotProjects(
+  supabase: SupabaseClient,
+  limit: number = 20
+): Promise<FullProject[]> {
+  const { data: projectsWithStats } = await supabase
+    .from('projects')
+    .select(
+      `
+      *,
+      profiles!projects_creator_fkey(*),
+      rounds(title, slug),
+      causes(title, slug),
+      project_votes!left(magnitude),
+      comments!left(id),
+      bids!left(amount, status),
+      txns!left(amount, type)
+    `
+    )
+    .neq('stage', 'hidden')
+    .neq('stage', 'draft')
+    .order('created_at', { ascending: false })
+    .throwOnError()
+  if (!projectsWithStats || projectsWithStats.length === 0) {
+    return []
+  }
+
+  // Calculate hot scores for all projects
+  const projectsWithScores = projectsWithStats.map((project) => {
+    const voteTotal =
+      project.project_votes?.reduce(
+        (sum: number, vote: any) => sum + (vote.magnitude || 0),
+        0
+      ) || 0
+    const commentCount = project.comments?.length || 0
+    const bidAmount =
+      project.bids?.reduce(
+        (sum: number, bid: any) =>
+          bid.status === 'approved' ? sum + (bid.amount || 0) : sum,
+        0
+      ) || 0
+    const txnAmount =
+      project.txns?.reduce(
+        (sum: number, txn: any) =>
+          txn.type === 'transfer' || txn.type === 'donate'
+            ? sum + (txn.amount || 0)
+            : sum,
+        0
+      ) || 0
+
+    const totalRaised = bidAmount + txnAmount
+    // minimal FullProject object with just the data needed for scoring
+    const tempFullProject: FullProject = {
+      ...project,
+      bids: totalRaised > 0 ? [] : [],
+      txns: totalRaised > 0 ? ([{ amount: totalRaised }] as any) : [],
+      comments: Array(commentCount).fill({ id: '' }),
+      project_votes:
+        voteTotal > 0
+          ? ([{ project_id: project.id, magnitude: voteTotal }] as any)
+          : [],
+      project_transfers: [],
+      project_follows: [],
+    }
+
+    return {
+      project: tempFullProject,
+      score: hotScore(tempFullProject),
+    }
+  })
+
+  projectsWithScores.sort((a, b) => a.score - b.score)
+  const topProjects = projectsWithScores.slice(0, limit)
+  const topProjectIds = topProjects.map((p) => p.project.id)
+  const fullProjects = await listProjects(supabase, topProjectIds)
+  return fullProjects
+}


### PR DESCRIPTION
Cache misses take ~4.2s to load the top 20 hot projects. Cache hits take 4ms