### PR TITLE
Additional comment fields in the API

### DIFF
--- a/app/api/v0/comments/route.ts
+++ b/app/api/v0/comments/route.ts
@@ -17,7 +17,9 @@ async function listCommentsPaginated(
       commenter,
       project,
       profiles!comments_commenter_fkey(username, full_name),
-      projects(title, slug)
+      projects(title, slug),
+      replying_to,
+      special_type
     `
     )
     .order('created_at', { ascending: false })

--- a/app/docs/page.tsx
+++ b/app/docs/page.tsx
@@ -84,7 +84,9 @@ const apis = [
     projects: {
       title: string,
       slug: string
-    }
+    },
+    replying_to: string,
+    special_type: string
   }
 ]`,
     curl: `curl https://manifund.org/api/v0/comments`,


### PR DESCRIPTION
There were a couple fields in the database that I was surprised weren't in the API responses. This PR adds `replying_to`, which will allow someone to reconstruct comment threads with context, and `special_type`, which will allow them to see if the comment is an official update from the creator or not.

I'm pulling this data to integrate into a dashboard/digest for myself and these would be useful signals to have. If these fields were omitted on purpose feel free to ignore this, they aren't required for what I'm doing but they would be nice.

I also wasn't able to formally test this, I got the local environment set up but without the database URL I wasn't able to import data from your live database. Once the PR previews are generated I can check it works there.