### PR TITLE
fix: source.unsplash.com/random was deprecated in 2024 (now 503s)

### DIFF
--- a/app/maxi/page.tsx
+++ b/app/maxi/page.tsx
@@ -29,7 +29,7 @@ export default async function Maxifund() {
               <img
                 className="aspect-square w-full object-cover"
                 alt={project.title}
-                src={`https://source.unsplash.com/random/400x400&${project.id}`}
+                src={`https://picsum.photos/seed/${project.id}/400/400`}
               />
               <div className="pointer-events-none absolute inset-0 flex items-end">
                 <span className="h-24 w-full bg-gradient-to-t from-black to-transparent opacity-50" />


### PR DESCRIPTION
`app/maxi/page.tsx` references the deprecated `source.unsplash.com/random` endpoint, which Unsplash retired in mid-2024 and which now returns HTTP 503 instead of an image.

---

#### Why this is needed

`source.unsplash.com/random` was deprecated by Unsplash in mid-2024 and the endpoint now returns 503 errors. Browser screenshots typically render a broken image icon instead of the intended placeholder.

You can verify in any browser:

```
curl -I https://source.unsplash.com/random/800x600?office
# HTTP/1.1 503 Service Unavailable
```

#### What this PR changes

Replaces the deprecated random-image URL on `/maxi` project cards with a seeded `picsum.photos` URL so each project gets a stable 400×400 placeholder.

#### Replacement details

Using `seed/${project.id}` gives the same one-image-per-project deterministic behaviour the original `&${project.id}` cache-buster had. Same dimensions.

#### Background

I'm tracking deprecated image-CDN URLs across public repos as part of [tteg](https://github.com/kiluazen/tteg), a tiny CLI/HTTP API I built to make it easy to drop real Unsplash photos into projects without registering an Unsplash app or managing API keys. tteg isn't a dependency of this PR — the fix above is dependency-free. But if you ever want to swap the static replacement for something topic-aware, the no-key HTTP API is at `https://tteg-api-53227342417.asia-south1.run.app/search?q=<query>&n=1` (CORS-on, no auth).

A 16k-files-across-885-repos summary of the deprecation is at [`kiluazen/tteg/RESEARCH.md`](https://github.com/kiluazen/tteg/blob/research-note-autark/RESEARCH.md).
