### PR TITLE
Fix silent approval failure for carol@ and hannah@ admins

### DIFF
--- a/app/admin/grant-verdict.tsx
+++ b/app/admin/grant-verdict.tsx
@@ -8,6 +8,7 @@ import { Modal } from '@/components/modal'
 import { HorizontalRadioGroup } from '@/components/radio-group'
 import { useRouter } from 'next/navigation'
 import { useEffect, useState } from 'react'
+import { toast } from 'react-hot-toast'
 import { Input } from '@/components/input'
 
 const REJECT_MESSAGE_INTRO = 'Manifund has declined to fund this project because we believe it'
@@ -163,7 +164,7 @@ export function GrantVerdict(props: {
               loading={isSubmitting}
               onClick={async () => {
                 setIsSubmitting(true)
-                await fetch('/api/issue-grant-verdict', {
+                const response = await fetch('/api/issue-grant-verdict', {
                   method: 'POST',
                   headers: {
                     'Content-Type': 'application/json',
@@ -176,6 +177,11 @@ export function GrantVerdict(props: {
                   }),
                 })
                 setIsSubmitting(false)
+                if (!response.ok) {
+                  const body = await response.json().catch(() => null)
+                  toast.error(body?.error ?? 'Failed to issue grant verdict.')
+                  return
+                }
                 setOpen(false)
                 router.refresh()
               }}

--- a/db/profile.ts
+++ b/db/profile.ts
@@ -16,12 +16,9 @@ export type ProfileWithRoles = Profile & {
   roles: ProfileRoles
 }
 
+const ADMINS = ['akrolsmir@gmail.com', 'hannah@manifund.org', 'carol@manifund.org']
+
 export function isAdmin(user: User | null) {
-  const ADMINS = [
-    'akrolsmir@gmail.com',
-    'hannah@manifund.org',
-    'carol@manifund.org',
-  ]
   return ADMINS.includes(user?.email ?? '')
 }
 

--- a/pages/api/issue-grant-verdict.ts
+++ b/pages/api/issue-grant-verdict.ts
@@ -3,7 +3,7 @@ import { NextRequest, NextResponse } from 'next/server'
 import { createAdminClient, getUserAndClient } from '@/db/edge'
 import { isAdmin } from '@/db/profile'
 import { getProjectById } from '@/db/project'
-import { getAdminName, getURL } from '@/utils/constants'
+import { getURL } from '@/utils/constants'
 import { getProfileById } from '@/db/profile'
 import { sendTemplateEmail, TEMPLATE_IDS } from '@/utils/email'
 import { maybeActivateProject } from '@/utils/activate-project'
@@ -24,14 +24,24 @@ export default async function handler(req: NextRequest) {
   const { approved, projectId, adminComment, publicBenefit } = (await req.json()) as VerdictProps
   const { supabase, user } = await getUserAndClient(req)
   if (!user || !isAdmin(user)) {
-    return NextResponse.error()
+    return NextResponse.json({ error: 'Only admins can issue grant verdicts.' }, { status: 403 })
   }
 
-  const adminName = getAdminName(user.email ?? '')
+  // Sign the verdict email with the admin's first name, from their profile
+  const adminProfile = await getProfileById(supabase, user.id)
+  const adminName = adminProfile?.full_name?.split(' ')[0]
+  if (!adminName) {
+    return NextResponse.json(
+      { error: `No profile name found for admin ${user.email}.` },
+      {
+        status: 500,
+      }
+    )
+  }
   const project = await getProjectById(supabase, projectId)
   const creator = await getProfileById(supabase, project?.creator)
-  if (!project || !creator || !adminName) {
-    return NextResponse.error()
+  if (!project || !creator) {
+    return NextResponse.json({ error: 'Project or project creator not found.' }, { status: 404 })
   }
 
   const supabaseAdmin = createAdminClient()
@@ -45,7 +55,10 @@ export default async function handler(req: NextRequest) {
   })
   if (error) {
     console.error(error)
-    return NextResponse.error()
+    return NextResponse.json(
+      { error: `Failed to execute grant verdict: ${error.message}` },
+      { status: 500 }
+    )
   }
 
   const recipientSubject = approved

--- a/utils/constants.ts
+++ b/utils/constants.ts
@@ -17,17 +17,6 @@ export function getURL() {
   return url
 }
 
-export function getAdminName(adminEmail: string) {
-  switch (adminEmail) {
-    case 'rachel.weinberg12@gmail.com':
-      return 'Rachel'
-    case 'akrolsmir@gmail.com':
-      return 'Austin'
-    default:
-      return null
-  }
-}
-
 export function getRoundTheme(roundTitle: string) {
   switch (roundTitle) {
     case 'ACX Mini-Grants':


### PR DESCRIPTION
## Problem

Approving a project as carol@manifund.org (or hannah@manifund.org) silently failed. There were two divergent admin lists:

- `isAdmin` in `db/profile.ts` — includes carol@ and hannah@
- `getAdminName` in `utils/constants.ts` — only knew Austin's and Rachel's emails

So carol/hannah passed the admin check, but `getAdminName` returned `null` and `issue-grant-verdict` returned an empty 500 **before executing the verdict**. The client then ignored the response, closed the modal, and refreshed — looking exactly like success.

## Fix

- **One admin list:** the email list in `isAdmin` (`db/profile.ts`) is now the only one. `getAdminName` and its stale email→name map are deleted from `utils/constants.ts`.
- **Display name from profile:** the verdict email signature is derived from the admin's `profiles` row (first word of `full_name`), so it can never diverge from the admin list again.
- **Server errors:** `issue-grant-verdict` returns JSON `{ error }` bodies with real status codes (403 non-admin, 404 missing project/creator, 500 with the message on RPC failure) instead of bodyless `NextResponse.error()`.
- **Client errors:** the verdict modal checks `response.ok`, shows a `toast.error` with the server's message, and stays open for retry instead of closing as if it succeeded.

## Testing

- `bun run build` passes.
- Verified end-to-end on the local site against prod: Carol approved "AI Safety Nepal" — the verdict executed, the project activated, and the verdict/activation emails sent. (That test predates the profile-name refactor; the profile lookup path is build-verified.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)