### PR TITLE
Enable spam filter, not enforced yet

### DIFF
--- a/utils/constants.ts
+++ b/utils/constants.ts
@@ -11,7 +11,7 @@ export const SIGNUP_DISABLED_MESSAGE =
 //   banned, for accounts < 1 week old) and the creator is emailed. When false,
 //   the verdict is only recorded to project_scores.is_spam (shadow mode) so you
 //   can review accuracy on live traffic before turning on enforcement.
-export const SPAM_FILTER_ENABLED = false
+export const SPAM_FILTER_ENABLED = true
 export const SPAM_FILTER_ENFORCE = false
 
 export function getURL() {


### PR DESCRIPTION
Sets `SPAM_FILTER_ENABLED=true`, `SPAM_FILTER_ENFORCE=false` — classifies new projects and records verdicts to `project_scores.is_spam`, but doesn't hide/ban/email yet.