### PR TITLE
Fix spam-filter edge cases and empty weekly digest

### DIFF
--- a/app/utils/spam-scores.ts
+++ b/app/utils/spam-scores.ts
@@ -4,6 +4,7 @@ import OpenAI from 'openai'
 import { toMarkdown } from '@/utils/tiptap-parsing'
 import { getUserEmail, sendTemplateEmail, TEMPLATE_IDS } from '@/utils/email'
 import { superbanUser } from '@/db/superban'
+import { getURL } from '@/utils/constants'
 
 // Spam gate that runs BEFORE the expensive Pangram + quality scoring. It only
 // catches blatant advertising/scam "billboards" (drug sales, phishing, fake
@@ -16,8 +17,6 @@ const PRIMARY_MODEL = 'anthropic/claude-sonnet-5'
 const FALLBACK_MODEL = 'anthropic/claude-haiku-4-5'
 
 const MIN_SPAM_CONTENT_CHARS = 15
-
-const SITE_URL = 'https://manifund.org'
 
 // New accounts posting spam are almost always throwaway spammer accounts, so we
 // delete them. Older accounts that post spam might be a compromised or confused
@@ -169,7 +168,7 @@ async function emailSpamNotice(
     TEMPLATE_IDS.GENERIC_NOTIF,
     {
       notifText: `Your Manifund project "${project.title}" was ${actionText}. If you believe this was a mistake, reply to this email and we'll take a look.\n\nFor your reference, here is what you submitted:\n\n${proposalText}`,
-      buttonUrl: SITE_URL,
+      buttonUrl: getURL(),
       buttonText: 'Go to Manifund',
       subject: 'Your Manifund project was flagged by our spam filter',
     },

--- a/app/utils/spam-scores.ts
+++ b/app/utils/spam-scores.ts
@@ -4,7 +4,6 @@ import OpenAI from 'openai'
 import { toMarkdown } from '@/utils/tiptap-parsing'
 import { getUserEmail, sendTemplateEmail, TEMPLATE_IDS } from '@/utils/email'
 import { superbanUser } from '@/db/superban'
-import { getURL } from '@/utils/constants'
 
 // Spam gate that runs BEFORE the expensive Pangram + quality scoring. It only
 // catches blatant advertising/scam "billboards" (drug sales, phishing, fake
@@ -15,6 +14,16 @@ import { getURL } from '@/utils/constants'
 
 const PRIMARY_MODEL = 'anthropic/claude-sonnet-5'
 const FALLBACK_MODEL = 'anthropic/claude-haiku-4-5'
+
+// A project with almost no content can't be an advertising billboard, so it's
+// never spam. Keeps empty/test posts (e.g. "test" with an empty body) from being
+// flagged - and, for new accounts, banned.
+const MIN_SPAM_CONTENT_CHARS = 15
+
+// Canonical site URL for links in user-facing emails. Hardcoded (not getURL())
+// so a run outside prod - e.g. the retro cleanup script - never emails a real
+// user a localhost link.
+const SITE_URL = 'https://manifund.org'
 
 // New accounts posting spam are almost always throwaway spammer accounts, so we
 // delete them. Older accounts that post spam might be a compromised or confused
@@ -34,6 +43,7 @@ Do NOT flag (these are NOT spam — set is_spam=false even if low-quality or off
 - Any sincere request for a grant to BUILD, RESEARCH, or DO something — even if it is commercial, a startup, a crypto/token project, off-mission, grandiose, vague, AI-written, eccentric, or unlikely to be funded. That is a real proposal; other filters handle quality.
 - A project that describes a product/service it wants to build and gives a budget or funding breakdown. Asking Manifund for money = not spam.
 - Research or charity work that merely mentions drugs, medicine, prescriptions, pharmacies, cost, or discounts.
+- Empty, blank, test, or placeholder projects (title like "test", "asdf", "delete this", nonsense, or with little or no real content) — these are not advertisements, just empty or unfinished. Never flag them.
 
 If the post asks Manifund for funding to do something, is_spam is FALSE — no matter how bad or commercial it is. Only flag pure advertisements/scams that are not funding requests at all. When in doubt, is_spam=false.
 
@@ -101,6 +111,14 @@ export async function classifyProjectSpam(project: {
   description: JSONContent | null
 }): Promise<SpamVerdict> {
   const text = spamText(project)
+  if (text.replace(/\s+/g, '').length < MIN_SPAM_CONTENT_CHARS) {
+    return {
+      is_spam: false,
+      confidence: 1,
+      reason: 'too little content to be spam',
+      model: 'guard',
+    }
+  }
   try {
     return await classifyWithModel(text, PRIMARY_MODEL)
   } catch (primaryError) {
@@ -157,7 +175,7 @@ async function emailSpamNotice(
     TEMPLATE_IDS.GENERIC_NOTIF,
     {
       notifText: `Your Manifund project "${project.title}" was ${actionText}. If you believe this was a mistake, reply to this email and we'll take a look.\n\nFor your reference, here is what you submitted:\n\n${proposalText}`,
-      buttonUrl: `${getURL()}`,
+      buttonUrl: SITE_URL,
       buttonText: 'Go to Manifund',
       subject: 'Your Manifund project was flagged by our spam filter',
     },

--- a/app/utils/spam-scores.ts
+++ b/app/utils/spam-scores.ts
@@ -15,14 +15,8 @@ import { superbanUser } from '@/db/superban'
 const PRIMARY_MODEL = 'anthropic/claude-sonnet-5'
 const FALLBACK_MODEL = 'anthropic/claude-haiku-4-5'
 
-// A project with almost no content can't be an advertising billboard, so it's
-// never spam. Keeps empty/test posts (e.g. "test" with an empty body) from being
-// flagged - and, for new accounts, banned.
 const MIN_SPAM_CONTENT_CHARS = 15
 
-// Canonical site URL for links in user-facing emails. Hardcoded (not getURL())
-// so a run outside prod - e.g. the retro cleanup script - never emails a real
-// user a localhost link.
 const SITE_URL = 'https://manifund.org'
 
 // New accounts posting spam are almost always throwaway spammer accounts, so we

--- a/utils/weekly-digest.ts
+++ b/utils/weekly-digest.ts
@@ -116,6 +116,28 @@ const getOneWeekAgo = (): Date => {
   return date
 }
 
+// Supabase's PostgREST rejects an `.in(col, ids)` once the id list makes the
+// request URL too long (~640 ids in practice), returning a "Bad Request"
+// error rather than the rows. Split large id lists into batches so a busy
+// week (or a spam wave) can't silently truncate the query. Errors throw
+// instead of being swallowed into an empty result.
+const IN_CHUNK_SIZE = 200
+
+async function selectByIdsChunked<Row>(
+  ids: string[],
+  runChunk: (
+    chunk: string[]
+  ) => PromiseLike<{ data: Row[] | null; error: { message: string } | null }>
+): Promise<Row[]> {
+  const rows: Row[] = []
+  for (let i = 0; i < ids.length; i += IN_CHUNK_SIZE) {
+    const { data, error } = await runChunk(ids.slice(i, i + IN_CHUNK_SIZE))
+    if (error) throw new Error(`weekly digest chunked query failed: ${error.message}`)
+    if (data) rows.push(...data)
+  }
+  return rows
+}
+
 // Data fetching functions
 export async function getRegrantorEmails(
   supabase: SupabaseClient,
@@ -164,18 +186,26 @@ export async function getNewProjectsLastWeek(
 
   const projectIds = projectsBase.map((p) => p.id)
   const [votes, comments, bids, txns] = await Promise.all([
-    supabase.from('project_votes').select('project_id, magnitude').in('project_id', projectIds),
-    supabase.from('comments').select('project, id').in('project', projectIds),
-    supabase.from('bids').select('*').in('project', projectIds),
-    supabase.from('txns').select('*').in('project', projectIds),
+    selectByIdsChunked(projectIds, (chunk) =>
+      supabase.from('project_votes').select('project_id, magnitude').in('project_id', chunk)
+    ),
+    selectByIdsChunked(projectIds, (chunk) =>
+      supabase.from('comments').select('project, id').in('project', chunk)
+    ),
+    selectByIdsChunked(projectIds, (chunk) =>
+      supabase.from('bids').select('*').in('project', chunk)
+    ),
+    selectByIdsChunked(projectIds, (chunk) =>
+      supabase.from('txns').select('*').in('project', chunk)
+    ),
   ])
 
   const projects: FullProject[] = projectsBase.map((project) => ({
     ...project,
-    project_votes: votes.data?.filter((v) => v.project_id === project.id) || [],
-    comments: comments.data?.filter((c) => c.project === project.id) || [],
-    bids: bids.data?.filter((b) => b.project === project.id) || [],
-    txns: txns.data?.filter((t) => t.project === project.id) || [],
+    project_votes: votes.filter((v) => v.project_id === project.id),
+    comments: comments.filter((c) => c.project === project.id),
+    bids: bids.filter((b) => b.project === project.id),
+    txns: txns.filter((t) => t.project === project.id),
     project_transfers: [],
     project_follows: [],
   }))
@@ -311,14 +341,11 @@ export async function getLargeDonorsEmails(
 
   if (!largeDonorIds.length) return []
 
-  const { data: profiles } = await supabase
-    .from('profiles')
-    .select('id')
-    .in('id', largeDonorIds)
-    .eq('regranter_status', false)
-    .throwOnError()
+  const profiles = await selectByIdsChunked<{ id: string }>(largeDonorIds, (chunk) =>
+    supabase.from('profiles').select('id').in('id', chunk).eq('regranter_status', false)
+  )
 
-  if (!profiles?.length) return []
+  if (!profiles.length) return []
 
   const emails = await Promise.all(profiles.map((p) => getUserEmail(supabase, p.id)))
   return Array.from(new Set(emails.filter((email): email is string => email !== null)))
@@ -359,13 +386,11 @@ export async function getTopCreatorEmails(
 
   const topCreatorIds = Array.from(new Set(scored.map((p) => p.creatorId)))
 
-  const { data: users } = await supabase
-    .from('users')
-    .select('email')
-    .in('id', topCreatorIds)
-    .throwOnError()
+  const users = await selectByIdsChunked<{ email: string | null }>(topCreatorIds, (chunk) =>
+    supabase.from('users').select('email').in('id', chunk)
+  )
 
-  return (users ?? []).map((u) => u.email).filter((email): email is string => email !== null)
+  return users.map((u) => u.email).filter((email): email is string => email !== null)
 }
 
 // Content generation functions

--- a/utils/weekly-digest.ts
+++ b/utils/weekly-digest.ts
@@ -117,10 +117,8 @@ const getOneWeekAgo = (): Date => {
 }
 
 // Supabase's PostgREST rejects an `.in(col, ids)` once the id list makes the
-// request URL too long (~640 ids in practice), returning a "Bad Request"
-// error rather than the rows. Split large id lists into batches so a busy
-// week (or a spam wave) can't silently truncate the query. Errors throw
-// instead of being swallowed into an empty result.
+// request URL too long, returning a "Bad Request"
+// error rather than the rows. Split large id lists into batches to avoid errors. 
 const IN_CHUNK_SIZE = 200
 
 async function selectByIdsChunked<Row>(


### PR DESCRIPTION
- **Weekly digest:** chunk the `.in(id, …)` lookups so a long id list (e.g. a spam-wave week) can't blow past PostgREST's URL limit. That failure was being swallowed into an empty result, so last week's digest went out saying "No new projects were created this week" despite 18 eligible projects. Errors now throw instead of silently truncating, and the donor/creator recipient lookups are chunked too.

This branch also includes the change to stop flagging empty "test" posts as spam; I thought that was pushed already but apparently not, oops.

🤖 Generated with [Claude Code](https://claude.com/claude-code)