### PR TITLE
AIS Funder Bulletin: update Coefficient figures, date, and Other resources

### DIFF
--- a/app/ais-funder-bulletin/page.tsx
+++ b/app/ais-funder-bulletin/page.tsx
@@ -37,8 +37,8 @@ const AT_A_GLANCE: Row[] = [
   {
     name: 'Coefficient Giving',
     href: 'https://coefficientgiving.org/',
-    donated2025: { v: '$300M', n: 1 },
-    grants2025: { v: '184', n: 2 },
+    donated2025: { v: '$400M', n: 1 },
+    grants2025: { v: '226', n: 2 },
     expected2026: { v: '$1B', n: 3 },
     fte: '70',
     generalApps: false,
@@ -160,24 +160,23 @@ const AT_A_GLANCE: Row[] = [
 // is the plain-text version shown in the hover tooltip on each superscript marker.
 const NOTES: { node: React.ReactNode; text: string }[] = [
   {
-    text: 'coefficientgiving.org/funds/navigating-transformative-ai — Featured Grants table',
+    text: "Using public grants on https://coefficientgiving.org/funds for the Navigating Transformative AI Fund and the GCR Opportunities Fund. I don't know what the total of nonpublic AIS grants was; total giving in 2025 was reported as around $1B.",
     node: (
       <>
-        <A href="https://coefficientgiving.org/funds/navigating-transformative-ai">
-          https://coefficientgiving.org/funds/navigating-transformative-ai
-        </A>{' '}
-        Featured Grants table
+        Using public grants on{' '}
+        <A href="https://coefficientgiving.org/funds">https://coefficientgiving.org/funds</A>
+        &nbsp;for the Navigating Transformative AI Fund and the GCR Opportunities Fund. I don&apos;t
+        know what the total of nonpublic AIS grants was; total giving in 2025 was reported as around
+        $1B.
       </>
     ),
   },
   {
-    text: 'coefficientgiving.org/funds/navigating-transformative-ai — Featured Grants table',
+    text: 'grants listed on https://coefficientgiving.org/funds',
     node: (
       <>
-        <A href="https://coefficientgiving.org/funds/navigating-transformative-ai">
-          https://coefficientgiving.org/funds/navigating-transformative-ai
-        </A>{' '}
-        Featured Grants table
+        grants listed on{' '}
+        <A href="https://coefficientgiving.org/funds">https://coefficientgiving.org/funds</A>
       </>
     ),
   },

--- a/app/ais-funder-bulletin/page.tsx
+++ b/app/ais-funder-bulletin/page.tsx
@@ -7,7 +7,7 @@ export const metadata = {
   description: 'A digest of funders in the AI safety space.',
 }
 
-const LAST_UPDATED = 'July 27'
+const LAST_UPDATED = 'July 28'
 
 const LINK = 'text-orange-600 underline decoration-orange-500 decoration-dotted underline-offset-2'
 

--- a/app/ais-funder-bulletin/page.tsx
+++ b/app/ais-funder-bulletin/page.tsx
@@ -1241,6 +1241,14 @@ export default function AisFunderBulletinPage() {
             ))}
           </ol>
         </CollapsibleSection>
+
+        <h2 className="mb-4 mt-12 text-2xl font-bold text-gray-900">Other resources</h2>
+        <p className="text-sm text-gray-600 [&_a]:text-orange-600">
+          See another database of AIS funding at{' '}
+          <A href="https://aisafety.com/funding">https://aisafety.com/funding</A>&nbsp;and subscribe
+          to their newsletter at{' '}
+          <A href="https://aisafetyfunding.substack.com/">https://aisafetyfunding.substack.com/</A>.
+        </p>
       </div>
     </div>
   )


### PR DESCRIPTION
Follow-up to #189 (already merged). Updates Coefficient Giving's 2025 figures ($400M / 226 grants) and footnotes 1–2, bumps the last-updated date, and adds an Other resources section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)