### PR TITLE
Add ops scripts for idle balances, regrant export, and declined-grant…

### DIFF
--- a/scripts/email-idle-balances.ts
+++ b/scripts/email-idle-balances.ts
@@ -1,0 +1,82 @@
+import { createAdminClient } from '@/db/edge'
+import { sendTemplateEmail, TEMPLATE_IDS } from '@/utils/email'
+
+// Emails holders of long-idle withdrawable balances to flag the money hasn't been
+// forgotten. Recipients and amounts come from scripts/idle-cash-balances.ts.
+//
+// Usage:
+//   bun run scripts/email-idle-balances.ts --test <email>   # one sample to you
+//   bun run scripts/email-idle-balances.ts                  # dry run, prints all
+//   bun run scripts/email-idle-balances.ts --execute        # sends for real
+
+const RECIPIENTS = [
+  { username: 'Asterisk-Magazine', amount: 70_000 },
+  { username: 'Linch', amount: 35_457 },
+  { username: 'laurence_ai', amount: 32_000 },
+  { username: 'peterwildeford', amount: 10_050 },
+]
+
+const SUBJECT = 'Your Manifund balance'
+const BUTTON_TEXT = 'View your balance'
+
+const body = (amount: number) =>
+  `You're receiving this email because you've had a withdrawable balance of $${amount.toLocaleString(
+    'en-US'
+  )} on Manifund for at least a year. Of course, you're welcome to leave it on the platform, but just flagging to make sure the money hasn't been forgotten. Thank you!`
+
+const testIndex = process.argv.indexOf('--test')
+const TEST_EMAIL = testIndex !== -1 ? process.argv[testIndex + 1] : undefined
+const EXECUTE = process.argv.includes('--execute')
+
+async function main() {
+  const supabase = createAdminClient()
+
+  const targets = []
+  for (const r of RECIPIENTS) {
+    const { data: p } = await supabase
+      .from('profiles')
+      .select('id, username, full_name')
+      .eq('username', r.username)
+      .single()
+      .throwOnError()
+    targets.push({ ...p, amount: r.amount })
+  }
+
+  if (TEST_EMAIL) {
+    // Send one sample — rendered exactly as the first recipient's would be.
+    const sample = targets[0]
+    const model = {
+      notifText: body(sample.amount),
+      buttonUrl: `https://manifund.org/${sample.username}`,
+      buttonText: BUTTON_TEXT,
+      subject: SUBJECT,
+    }
+    console.log(`TEST -> ${TEST_EMAIL} (rendered as @${sample.username}'s copy)`)
+    console.log(JSON.stringify(model, null, 2))
+    await sendTemplateEmail(TEMPLATE_IDS.GENERIC_NOTIF, model, undefined, TEST_EMAIL)
+    return
+  }
+
+  for (const t of targets) {
+    const model = {
+      notifText: body(t.amount),
+      buttonUrl: `https://manifund.org/${t.username}`,
+      buttonText: BUTTON_TEXT,
+      subject: SUBJECT,
+    }
+    if (!EXECUTE) {
+      console.log(`\nDRY RUN -> ${t.full_name} (@${t.username})`)
+      console.log(model.notifText)
+      console.log(`[${model.buttonText}] ${model.buttonUrl}`)
+      continue
+    }
+    console.log(`Sending -> ${t.full_name} (@${t.username}) $${t.amount.toLocaleString()}`)
+    await sendTemplateEmail(TEMPLATE_IDS.GENERIC_NOTIF, model, t.id)
+  }
+  if (!EXECUTE) console.log('\nRe-run with --execute to send.')
+}
+
+main().catch((e) => {
+  console.error(e)
+  process.exit(1)
+})

--- a/scripts/export-regrants.ts
+++ b/scripts/export-regrants.ts
@@ -1,0 +1,133 @@
+import { createAdminClient } from '@/db/edge'
+import { getRegranters } from '@/db/profile'
+import * as fs from 'fs'
+import * as path from 'path'
+
+// Minimal recursive Tiptap → plaintext (mirrors app/about/regranting-data/page.tsx).
+function tiptapToText(node: any): string {
+  if (!node) return ''
+  if (typeof node === 'string') return node
+  if (node.type === 'text') return node.text ?? ''
+  if (Array.isArray(node.content)) {
+    return node.content.map(tiptapToText).join(' ')
+  }
+  return ''
+}
+
+async function exportRegrants() {
+  const supabase = createAdminClient()
+
+  const regrantors = await getRegranters(supabase)
+  const regrantorIds = regrantors.map((r) => r.id)
+  const regrantorMap = Object.fromEntries(regrantors.map((r) => [r.id, r]))
+  console.log(`Found ${regrantors.length} regrantors`)
+
+  const { data: grantTxns } = await supabase
+    .from('txns')
+    .select(
+      'id, amount, created_at, from_id, to_id, project, projects(id, title, slug, type, stage, blurb, creator)'
+    )
+    .in('from_id', regrantorIds)
+    .eq('type', 'project donation')
+    .eq('token', 'USD')
+    .not('project', 'is', null)
+    .order('created_at', { ascending: false })
+    .throwOnError()
+
+  const validTxns = (grantTxns ?? []).filter(
+    (t: any) => t.projects && t.projects.type === 'grant' && t.projects.stage !== 'hidden'
+  )
+  console.log(`Found ${validTxns.length} regrants`)
+
+  const projectIds = Array.from(new Set(validTxns.map((t: any) => t.project as string)))
+
+  // Regrantor comments on these projects (used as grant explanations).
+  const { data: regrantorComments } = projectIds.length
+    ? await supabase
+        .from('comments')
+        .select('id, project, commenter, content, created_at')
+        .in('commenter', regrantorIds)
+        .in('project', projectIds)
+        .order('created_at', { ascending: true })
+        .throwOnError()
+    : { data: [] }
+
+  const commentByKey: Record<string, string> = {}
+  for (const c of regrantorComments ?? []) {
+    const key = `${c.commenter}::${c.project}`
+    const text = tiptapToText(c.content).trim()
+    if (!text || text.length < 40) continue
+    if (!commentByKey[key]) commentByKey[key] = text
+  }
+
+  const rows = validTxns.map((t: any) => {
+    const r = regrantorMap[t.from_id as string]
+    const proj = t.projects
+    return {
+      date: (t.created_at as string).slice(0, 10),
+      regrantor_name: r?.full_name ?? 'Unknown',
+      regrantor_username: r?.username ?? '',
+      regrantor_id: t.from_id as string,
+      amount: t.amount as number,
+      project_title: proj?.title ?? 'Untitled',
+      project_slug: proj?.slug ?? '',
+      project_url: proj?.slug ? `https://manifund.org/projects/${proj.slug}` : '',
+      project_id: t.project as string,
+      comment: commentByKey[`${t.from_id}::${t.project}`] ?? '',
+      txn_id: t.id as string,
+    }
+  })
+
+  const headers = [
+    'Date',
+    'Regrantor Name',
+    'Regrantor Username',
+    'Regrantor ID',
+    'Amount (USD)',
+    'Project Title',
+    'Project Slug',
+    'Project URL',
+    'Project ID',
+    'Comment',
+    'Txn ID',
+  ]
+  const csvRows = rows.map((row) =>
+    [
+      row.date,
+      row.regrantor_name,
+      row.regrantor_username,
+      row.regrantor_id,
+      row.amount.toString(),
+      row.project_title,
+      row.project_slug,
+      row.project_url,
+      row.project_id,
+      row.comment,
+      row.txn_id,
+    ]
+      .map(escapeCsvField)
+      .join(',')
+  )
+
+  const csvContent = headers.join(',') + '\n' + csvRows.join('\n') + '\n'
+  const outputPath = path.join(__dirname, 'regrants.csv')
+  fs.writeFileSync(outputPath, csvContent, 'utf-8')
+
+  const total = rows.reduce((sum, r) => sum + r.amount, 0)
+  console.log(`\nExport complete!`)
+  console.log(`Output written to: ${outputPath}`)
+  console.log(`Total regrants: ${rows.length}`)
+  console.log(`Total amount: $${total.toLocaleString()}`)
+}
+
+function escapeCsvField(field: string): string {
+  if (field.includes(',') || field.includes('"') || field.includes('\n')) {
+    return `"${field.replace(/"/g, '""')}"`
+  }
+  return field
+}
+
+exportRegrants().catch((error) => {
+  console.error('Failed to export regrants:', error)
+  process.exit(1)
+})

--- a/scripts/idle-cash-balances.ts
+++ b/scripts/idle-cash-balances.ts
@@ -1,0 +1,225 @@
+import { createAdminClient } from '@/db/edge'
+
+// "Withdrawable balance" = calculateCashBalance (utils/math.ts): sum of
+// txn.amount * getTxnCashMultiplier(...) plus pending-bid locks. This distinguishes
+// withdrawable cash from charity-only funds (unaccredited deposits, cash->charity, etc).
+// "Aged N months" = the running withdrawable balance never dropped below that amount at
+// any point in the trailing N months, i.e. min(balance over window) is the portion that
+// has been sitting untouched for the whole window.
+//
+// Usage: bun run scripts/idle-cash-balances.ts [months] [threshold]
+
+const MONTHS = Number(process.argv[2] ?? 6)
+const THRESHOLD = Number(process.argv[3] ?? 10_000)
+const NOW = new Date('2026-07-31T00:00:00.000Z')
+const WINDOW_START = new Date(
+  Date.UTC(NOW.getUTCFullYear(), NOW.getUTCMonth() - MONTHS, NOW.getUTCDate())
+).toISOString()
+const IGNORE_ACCREDITATION_DATE = new Date('2023-11-02')
+const CHARITABLE_DEPOSITS = new Set([
+  '1e17c09d-aa7f-432a-b523-89691531b304',
+  'c223e240-598f-41a9-8aa0-7a961d8db258',
+])
+
+type Txn = {
+  id: string
+  amount: number
+  created_at: string
+  from_id: string | null
+  to_id: string
+  token: string
+  type: string | null
+  project: string | null
+}
+
+// Faithful port of getTxnCashMultiplier (utils/math.ts:270-311).
+function getTxnCashMultiplier(
+  txn: Txn,
+  userId: string,
+  projectCreator: string | null,
+  accredited: boolean
+) {
+  if (
+    txn.token !== 'USD' ||
+    (txn.from_id !== userId && txn.to_id !== userId) ||
+    txn.type === 'profile donation' ||
+    txn.type === 'tip' ||
+    txn.type === 'return bank funds'
+  ) {
+    return 0
+  }
+  const isIncoming = txn.to_id === userId
+  const isOwnProject = projectCreator === userId
+  const actuallyAccredited =
+    new Date(txn.created_at) < IGNORE_ACCREDITATION_DATE && accredited
+  if (txn.type === 'cash to charity transfer') return -1
+  if (isIncoming && txn.from_id === userId) return isOwnProject ? 1 : 0
+  if (txn.type === 'project donation') return isIncoming ? 1 : 0
+  if (txn.type === 'user to amm trade' || txn.type === 'user to user trade') {
+    if (isOwnProject || actuallyAccredited) return isIncoming ? 1 : -1
+    return 0
+  }
+  if (txn.type === 'inject amm liquidity') return isOwnProject ? (isIncoming ? 1 : -1) : 0
+  if (txn.type === 'deposit')
+    return actuallyAccredited && !CHARITABLE_DEPOSITS.has(txn.id) ? 1 : 0
+  if (txn.type === 'withdraw') return -1
+  return 0
+}
+
+async function pageAll<T>(query: (from: number, to: number) => any): Promise<T[]> {
+  const out: T[] = []
+  const PAGE = 1000
+  for (let offset = 0; ; offset += PAGE) {
+    const { data } = await query(offset, offset + PAGE - 1).throwOnError()
+    out.push(...((data ?? []) as T[]))
+    if (!data || data.length < PAGE) break
+  }
+  return out
+}
+
+async function main() {
+  const supabase = createAdminClient()
+
+  // Project -> creator (for isOwnProject).
+  const projects = await pageAll<{ id: string; creator: string }>((f, t) =>
+    supabase.from('projects').select('id, creator').range(f, t)
+  )
+  const creatorByProject = new Map(projects.map((p) => [p.id, p.creator]))
+  console.log(`Fetched ${projects.length} projects`)
+
+  // All USD txns.
+  const txns = await pageAll<Txn>((f, t) =>
+    supabase
+      .from('txns')
+      .select('id, amount, created_at, from_id, to_id, token, type, project')
+      .eq('token', 'USD')
+      .order('created_at', { ascending: true })
+      .range(f, t)
+  )
+  console.log(`Fetched ${txns.length} USD txns`)
+
+  // Accreditation status for every user who appears in a txn.
+  const userIds = new Set<string>()
+  for (const t of txns) {
+    if (t.to_id) userIds.add(t.to_id)
+    if (t.from_id) userIds.add(t.from_id)
+  }
+  const accreditedById = new Map<string, boolean>()
+  const idList = Array.from(userIds)
+  for (let i = 0; i < idList.length; i += 500) {
+    const { data } = await supabase
+      .from('profiles')
+      .select('id, accreditation_status')
+      .in('id', idList.slice(i, i + 500))
+      .throwOnError()
+    for (const p of data ?? []) accreditedById.set(p.id, !!p.accreditation_status)
+  }
+
+  // Pending bids -> per-user withdrawable lock (getBidCashMultiplier: -1 for a
+  // pending buy/donate bid on the bidder's OWN non-hidden project).
+  const bids = await pageAll<{
+    amount: number
+    status: string
+    type: string
+    bidder: string
+    projects: { creator: string; stage: string } | null
+  }>((f, t) =>
+    supabase
+      .from('bids')
+      .select('amount, status, type, bidder, projects(creator, stage)')
+      .eq('status', 'pending')
+      .range(f, t)
+  )
+  const bidLockByUser = new Map<string, number>()
+  for (const b of bids) {
+    if (!b.projects) continue
+    const projectIsBidders = b.projects.creator === b.bidder
+    if (
+      b.type === 'sell' ||
+      b.type === 'assurance sell' ||
+      b.projects.stage === 'hidden' ||
+      !projectIsBidders
+    )
+      continue
+    bidLockByUser.set(b.bidder, (bidLockByUser.get(b.bidder) ?? 0) - b.amount)
+  }
+
+  // Per-user signed withdrawable deltas, chronological.
+  const deltasByUser = new Map<string, { created_at: string; delta: number }[]>()
+  const push = (userId: string, created_at: string, delta: number) => {
+    if (delta === 0) return
+    if (!deltasByUser.has(userId)) deltasByUser.set(userId, [])
+    deltasByUser.get(userId)!.push({ created_at, delta })
+  }
+  for (const t of txns) {
+    const creator = t.project ? creatorByProject.get(t.project) ?? null : null
+    for (const uid of new Set([t.to_id, t.from_id].filter(Boolean) as string[])) {
+      const m = getTxnCashMultiplier(t, uid, creator, accreditedById.get(uid) ?? false)
+      if (m !== 0) push(uid, t.created_at, t.amount * m)
+    }
+  }
+
+  const qualifying: { userId: string; current: number; aged: number }[] = []
+  for (const [userId, deltas] of deltasByUser) {
+    deltas.sort((a, b) => a.created_at.localeCompare(b.created_at))
+    let bal = 0
+    let i = 0
+    for (; i < deltas.length && deltas[i].created_at < WINDOW_START; i++) bal += deltas[i].delta
+    let aged = bal
+    for (; i < deltas.length; i++) {
+      bal += deltas[i].delta
+      if (bal < aged) aged = bal
+    }
+    // Current withdrawable includes pending-bid locks (matches calculateCashBalance).
+    const current = bal + (bidLockByUser.get(userId) ?? 0)
+    // Pending-bid locks eat into the aged portion too.
+    aged = Math.min(aged, current)
+    if (aged >= THRESHOLD) {
+      qualifying.push({ userId, current, aged })
+    }
+  }
+
+  qualifying.sort((a, b) => b.aged - a.aged)
+
+  const nameById = new Map<string, { full_name: string; username: string }>()
+  const qIds = qualifying.map((q) => q.userId)
+  for (let i = 0; i < qIds.length; i += 500) {
+    const { data } = await supabase
+      .from('profiles')
+      .select('id, full_name, username')
+      .in('id', qIds.slice(i, i + 500))
+      .throwOnError()
+    for (const p of data ?? []) nameById.set(p.id, p as any)
+  }
+
+  const fmt = (n: number) =>
+    '$' + n.toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 })
+
+  console.log(
+    `\n${qualifying.length} people held >= $${THRESHOLD.toLocaleString()} withdrawable continuously since ${WINDOW_START.slice(0, 10)} (${MONTHS} months):\n`
+  )
+  console.log(
+    'Name'.padEnd(30),
+    `Aged ${MONTHS}mo`.padStart(15),
+    'Current'.padStart(16),
+    '  @username'
+  )
+  console.log('-'.repeat(82))
+  for (const q of qualifying) {
+    const p = nameById.get(q.userId)
+    console.log(
+      (p?.full_name ?? 'Unknown').slice(0, 29).padEnd(30),
+      fmt(q.aged).padStart(15),
+      fmt(q.current).padStart(16),
+      '  @' + (p?.username ?? q.userId)
+    )
+  }
+  const totalAged = qualifying.reduce((s, q) => s + q.aged, 0)
+  console.log('-'.repeat(82))
+  console.log(`Total aged >= ${MONTHS}mo across these ${qualifying.length} people: ${fmt(totalAged)}`)
+}
+
+main().catch((e) => {
+  console.error(e)
+  process.exit(1)
+})

--- a/scripts/return-declined-grant.ts
+++ b/scripts/return-declined-grant.ts
@@ -1,0 +1,126 @@
+import { createAdminClient } from '@/db/edge'
+import { getTxnAndProjectsByUser } from '@/db/txn'
+import { getPendingBidsByUser } from '@/db/bid'
+import { calculateCashBalance, calculateCharityBalance } from '@/utils/math'
+
+// Returns declined grant funds from a grantee back to a fund account.
+//
+// Grant money arrives as an incoming 'project donation', which credits the
+// grantee's CASH balance and leaves charity balance at 0. There is no single txn
+// type that moves cash from one profile to another, so this is two rows:
+//   1. 'cash to charity transfer' (self-txn): -1 cash, +1 charity for the grantee
+//   2. 'profile donation' to the fund:        -1 charity for grantee, +1 for fund
+// Skipping row 1 would move the money while leaving the grantee's withdrawable
+// balance intact, letting them withdraw funds they no longer have.
+//
+// Usage: bun run scripts/return-declined-grant.ts <fromUsername> <toUser>:<amount> [...] [--execute]
+//   e.g. ... andrewluskin acx-grants:25000
+//        ... StevePetersen Austin:1000 TassiloNeubauer:500 NeelNanda:10500
+
+const argv = process.argv.slice(2).filter((a) => a !== '--execute')
+const EXECUTE = process.argv.includes('--execute')
+const fromUsername = argv[0]
+const recipients = argv.slice(1).map((pair) => {
+  const [username, amt] = pair.split(':')
+  return { username, amount: Number(amt) }
+})
+
+if (
+  !fromUsername ||
+  !recipients.length ||
+  recipients.some((r) => !r.username || !Number.isFinite(r.amount) || r.amount <= 0)
+) {
+  console.error(
+    'Usage: bun run scripts/return-declined-grant.ts <fromUsername> <toUser>:<amount> [...] [--execute]'
+  )
+  process.exit(1)
+}
+const amount = recipients.reduce((s, r) => s + r.amount, 0)
+
+const fmt = (n: number) =>
+  '$' + n.toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 })
+
+async function balances(supabase: any, id: string, accredited: boolean) {
+  const txns = await getTxnAndProjectsByUser(supabase, id)
+  const bids = await getPendingBidsByUser(supabase, id)
+  return {
+    cash: calculateCashBalance(txns, bids, id, accredited),
+    charity: calculateCharityBalance(txns, bids, id, accredited),
+  }
+}
+
+async function main() {
+  const supabase = createAdminClient()
+
+  const { data: from } = await supabase
+    .from('profiles')
+    .select('id, username, full_name, accreditation_status')
+    .eq('username', fromUsername)
+    .single()
+    .throwOnError()
+  const tos = []
+  for (const r of recipients) {
+    const { data: to } = await supabase
+      .from('profiles')
+      .select('id, username, full_name, accreditation_status, type')
+      .eq('username', r.username)
+      .single()
+      .throwOnError()
+    tos.push({ ...to, amount: r.amount })
+  }
+
+  const before = await balances(supabase, from.id, from.accreditation_status)
+  console.log(`From: ${from.full_name} (@${from.username}) ${from.id}`)
+  console.log(`  cash ${fmt(before.cash)} | charity ${fmt(before.charity)}`)
+  for (const to of tos) {
+    console.log(`To:   ${to.full_name} (@${to.username}) ${to.id} [${to.type}] ${fmt(to.amount)}`)
+  }
+  console.log(`Total: ${fmt(amount)}\n`)
+
+  if (before.cash < amount) {
+    console.error(`ABORT: cash balance ${fmt(before.cash)} < ${fmt(amount)}`)
+    process.exit(1)
+  }
+
+  const rows = [
+    {
+      from_id: from.id,
+      to_id: from.id,
+      amount,
+      token: 'USD',
+      type: 'cash to charity transfer' as const,
+      project: null,
+    },
+    ...tos.map((to) => ({
+      from_id: from.id,
+      to_id: to.id,
+      amount: to.amount,
+      token: 'USD',
+      type: 'profile donation' as const,
+      project: null,
+    })),
+  ]
+
+  if (!EXECUTE) {
+    console.log('DRY RUN — would insert:')
+    for (const r of rows) console.log(' ', JSON.stringify(r))
+    console.log('\nRe-run with --execute to write.')
+    return
+  }
+
+  const { data: inserted } = await supabase.from('txns').insert(rows).select('id, type').throwOnError()
+  console.log('Inserted:')
+  for (const r of inserted ?? []) console.log(' ', r.id, r.type)
+
+  const after = await balances(supabase, from.id, from.accreditation_status)
+  console.log(
+    `\n${from.username}: cash ${fmt(before.cash)} -> ${fmt(after.cash)} | charity ${fmt(
+      before.charity
+    )} -> ${fmt(after.charity)}`
+  )
+}
+
+main().catch((e) => {
+  console.error(e)
+  process.exit(1)
+})


### PR DESCRIPTION
committing scripts used for ops tasks: finding idle balances, emailing users with idle balances, returning declined grants, and exporting regrants for analysis

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added administrative tools for reviewing idle cash balances and identifying qualifying accounts.
  * Added email preview, dry-run, and execution options for balance notifications.
  * Added CSV export for eligible regrant activity, including project and comment details.
  * Added a guided workflow for returning declined grants, with validation, transfer previews, and optional execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->