### PR TITLE
Add reply-to-donor thank-you threads

### DIFF
--- a/app/projects/[slug]/project-tabs.tsx
+++ b/app/projects/[slug]/project-tabs.tsx
@@ -120,7 +120,6 @@ export function ProjectTabs(props: {
           replyContext={{
             projectId: project.id,
             projectSlug: project.slug,
-            creatorId: project.creator,
             userProfile,
           }}
         />

--- a/app/projects/[slug]/project-tabs.tsx
+++ b/app/projects/[slug]/project-tabs.tsx
@@ -114,7 +114,17 @@ export function ProjectTabs(props: {
       name: 'Donations',
       id: 'donations',
       count: donations.length,
-      display: <DonationsHistory donations={donations} />,
+      display: (
+        <DonationsHistory
+          donations={donations}
+          replyContext={{
+            projectId: project.id,
+            projectSlug: project.slug,
+            creatorId: project.creator,
+            userProfile,
+          }}
+        />
+      ),
     })
   }
 

--- a/components/donations-history.tsx
+++ b/components/donations-history.tsx
@@ -17,17 +17,14 @@ import { useTextEditor } from '@/hooks/use-text-editor'
 import { IconButton } from './button'
 import { PaperAirplaneIcon } from '@heroicons/react/24/solid'
 import { ArrowUturnRightIcon } from '@heroicons/react/24/outline'
-import { Tooltip } from './tooltip'
 import { clearLocalStorageItem } from '@/hooks/use-local-storage'
 
-// When rendered on a grant project by its creator, `replyContext` adds a
-// "Reply" button to each donation that posts a public comment thanking the
-// donor (mentioning them, so they're notified). Just an ordinary top-level
-// comment via /api/post-comment — no special DB machinery.
+// `replyContext` adds a "Reply" button to each donation (for any logged-in
+// user) that posts a public comment mentioning the donor. Just an ordinary
+// top-level comment via /api/post-comment — no special DB machinery.
 type ReplyContext = {
   projectId: string
   projectSlug: string
-  creatorId: string
   userProfile?: Profile
 }
 
@@ -92,7 +89,7 @@ export function ExpandableDonationsHistory(props: { donations: TxnAndProfiles[] 
 export function Donation(props: { txn: TxnAndProfiles; replyContext?: ReplyContext }) {
   const { txn, replyContext } = props
   const [replying, setReplying] = useState(false)
-  const canReply = !!replyContext && replyContext.userProfile?.id === replyContext.creatorId
+  const canReply = !!replyContext?.userProfile
   return (
     <div className="rounded p-2">
       <Row className="justify-between">
@@ -103,15 +100,13 @@ export function Donation(props: { txn: TxnAndProfiles; replyContext?: ReplyConte
         </Row>
         <Row className="items-center gap-2">
           {canReply && (
-            <Tooltip text="Reply to thank this donor">
-              <button
-                onClick={() => setReplying((r) => !r)}
-                className="flex items-center gap-1 text-sm text-gray-500 hover:text-orange-500"
-              >
-                <ArrowUturnRightIcon className="h-4 w-4 rotate-180 stroke-2" />
-                Reply
-              </button>
-            </Tooltip>
+            <button
+              onClick={() => setReplying((r) => !r)}
+              className="flex items-center gap-1 text-sm text-gray-500 hover:text-orange-500"
+            >
+              <ArrowUturnRightIcon className="h-4 w-4 rotate-180 stroke-2" />
+              Reply
+            </button>
           )}
           <span className="text-sm text-gray-500">
             {format(new Date(txn.created_at), 'yyyy-MM-dd')}
@@ -120,14 +115,18 @@ export function Donation(props: { txn: TxnAndProfiles; replyContext?: ReplyConte
       </Row>
       {replying && canReply && replyContext && (
         <div className="mt-2">
-          <ThankDonorBox txn={txn} replyContext={replyContext} onClose={() => setReplying(false)} />
+          <DonationReplyBox
+            txn={txn}
+            replyContext={replyContext}
+            onClose={() => setReplying(false)}
+          />
         </div>
       )}
     </div>
   )
 }
 
-function ThankDonorBox(props: {
+function DonationReplyBox(props: {
   txn: TxnAndProfiles
   replyContext: ReplyContext
   onClose: () => void
@@ -136,8 +135,8 @@ function ThankDonorBox(props: {
   const router = useRouter()
   const [isSubmitting, setIsSubmitting] = useState(false)
   const donor = txn.profiles as Profile
-  const storageKey = `ThankDonor${txn.id}`
-  // Seed the editor with a mention of the donor so the thank-you is addressed to
+  const storageKey = `DonationReply${txn.id}`
+  // Seed the editor with a mention of the donor so the reply is addressed to
   // them (and they get a mention notification on top of the follower email).
   const startingText: JSONContent = {
     type: 'doc',
@@ -154,7 +153,7 @@ function ThankDonorBox(props: {
   const editor = useTextEditor(
     startingText,
     storageKey,
-    `Say thanks to ${donor.full_name || donor.username}...`,
+    `Reply to ${donor.full_name || donor.username}...`,
     'border-0 focus:!outline-none focus:ring-0 text-sm sm:text-md'
   )
   const handleSubmit = async () => {

--- a/components/donations-history.tsx
+++ b/components/donations-history.tsx
@@ -154,24 +154,29 @@ function ThankDonorBox(props: {
   const editor = useTextEditor(
     startingText,
     storageKey,
-    `Say thanks to ${donor.full_name}...`,
+    `Say thanks to ${donor.full_name || donor.username}...`,
     'border-0 focus:!outline-none focus:ring-0 text-sm sm:text-md'
   )
   const handleSubmit = async () => {
     const content = editor?.getJSON() as JSONContent | undefined
     if (!editor || !editor.getText()?.trim() || !content) return
     setIsSubmitting(true)
-    await fetch('/api/post-comment', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ content, projectId: replyContext.projectId }),
-    })
-    editor.commands.clearContent()
-    clearLocalStorageItem(storageKey)
-    setIsSubmitting(false)
-    onClose()
-    router.push(`/projects/${replyContext.projectSlug}?tab=comments`)
-    router.refresh()
+    try {
+      const res = await fetch('/api/post-comment', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ content, projectId: replyContext.projectId }),
+      })
+      // On failure, keep the typed reply and the box open so nothing is lost.
+      if (!res.ok) return
+      editor.commands.clearContent()
+      clearLocalStorageItem(storageKey)
+      onClose()
+      router.push(`/projects/${replyContext.projectSlug}?tab=comments`)
+      router.refresh()
+    } finally {
+      setIsSubmitting(false)
+    }
   }
   return (
     <div className="relative w-full overflow-hidden rounded-xl rounded-tl-sm bg-white p-0 shadow">
@@ -184,7 +189,8 @@ function ThankDonorBox(props: {
         <Row className="absolute bottom-0 w-full items-center justify-between border-t border-t-gray-200 bg-white py-0.5 pl-3">
           <button
             onClick={onClose}
-            className="text-sm text-gray-500 hover:cursor-pointer hover:text-gray-700"
+            disabled={isSubmitting}
+            className="text-sm text-gray-500 hover:cursor-pointer hover:text-gray-700 disabled:opacity-50"
           >
             Cancel
           </button>

--- a/components/donations-history.tsx
+++ b/components/donations-history.tsx
@@ -6,20 +6,45 @@ import clsx from 'clsx'
 import { format } from 'date-fns'
 import { orderBy, uniq } from 'es-toolkit'
 import { useState } from 'react'
+import { useRouter } from 'next/navigation'
+import { JSONContent } from '@tiptap/react'
 import { Avatar } from './avatar'
 import { RightCarrotIcon } from './icons'
 import { Row } from './layout/row'
 import { UserAvatarAndBadge } from './user-link'
+import { TextEditor } from './editor'
+import { useTextEditor } from '@/hooks/use-text-editor'
+import { IconButton } from './button'
+import { PaperAirplaneIcon } from '@heroicons/react/24/solid'
+import { ArrowUturnRightIcon } from '@heroicons/react/24/outline'
+import { Tooltip } from './tooltip'
+import { clearLocalStorageItem } from '@/hooks/use-local-storage'
 
-export function DonationsHistory(props: { donations: TxnAndProfiles[] }) {
-  const { donations } = props
+// When rendered on a grant project by its creator, `replyContext` adds a
+// "Reply" button to each donation that posts a public comment thanking the
+// donor (mentioning them, so they're notified). Just an ordinary top-level
+// comment via /api/post-comment — no special DB machinery.
+type ReplyContext = {
+  projectId: string
+  projectSlug: string
+  creatorId: string
+  userProfile?: Profile
+}
+
+export function DonationsHistory(props: {
+  donations: TxnAndProfiles[]
+  replyContext?: ReplyContext
+}) {
+  const { donations, replyContext } = props
   const sortedDonations = orderBy(donations, ['created_at'], ['desc'])
   return (
     <>
       {donations.length > 0 ? (
         <>
           {sortedDonations.map((txn) => {
-            return txn.profiles ? <Donation txn={txn} /> : null
+            return txn.profiles ? (
+              <Donation key={txn.id} txn={txn} replyContext={replyContext} />
+            ) : null
           })}
         </>
       ) : (
@@ -64,20 +89,115 @@ export function ExpandableDonationsHistory(props: { donations: TxnAndProfiles[] 
   )
 }
 
-export function Donation(props: { txn: TxnAndProfiles }) {
-  const { txn } = props
+export function Donation(props: { txn: TxnAndProfiles; replyContext?: ReplyContext }) {
+  const { txn, replyContext } = props
+  const [replying, setReplying] = useState(false)
+  const canReply = !!replyContext && replyContext.userProfile?.id === replyContext.creatorId
   return (
-    <Row key={txn.id} className="justify-between rounded p-2">
-      <Row className="items-center gap-1">
-        <UserAvatarAndBadge profile={txn.profiles as Profile} />
-        <span className="text-gray-600"> donated </span>
-        <span>{formatMoney(txn.amount)}</span>
+    <div className="rounded p-2">
+      <Row className="justify-between">
+        <Row className="items-center gap-1">
+          <UserAvatarAndBadge profile={txn.profiles as Profile} />
+          <span className="text-gray-600"> donated </span>
+          <span>{formatMoney(txn.amount)}</span>
+        </Row>
+        <Row className="items-center gap-2">
+          {canReply && (
+            <Tooltip text="Reply to thank this donor">
+              <button
+                onClick={() => setReplying((r) => !r)}
+                className="flex items-center gap-1 text-sm text-gray-500 hover:text-orange-500"
+              >
+                <ArrowUturnRightIcon className="h-4 w-4 rotate-180 stroke-2" />
+                Reply
+              </button>
+            </Tooltip>
+          )}
+          <span className="text-sm text-gray-500">
+            {format(new Date(txn.created_at), 'yyyy-MM-dd')}
+          </span>
+        </Row>
       </Row>
-      <Row className="items-center">
-        <span className="text-sm text-gray-500">
-          {format(new Date(txn.created_at), 'yyyy-MM-dd')}
-        </span>
-      </Row>
-    </Row>
+      {replying && canReply && replyContext && (
+        <div className="mt-2">
+          <ThankDonorBox txn={txn} replyContext={replyContext} onClose={() => setReplying(false)} />
+        </div>
+      )}
+    </div>
+  )
+}
+
+function ThankDonorBox(props: {
+  txn: TxnAndProfiles
+  replyContext: ReplyContext
+  onClose: () => void
+}) {
+  const { txn, replyContext, onClose } = props
+  const router = useRouter()
+  const [isSubmitting, setIsSubmitting] = useState(false)
+  const donor = txn.profiles as Profile
+  const storageKey = `ThankDonor${txn.id}`
+  // Seed the editor with a mention of the donor so the thank-you is addressed to
+  // them (and they get a mention notification on top of the follower email).
+  const startingText: JSONContent = {
+    type: 'doc',
+    content: [
+      {
+        type: 'paragraph',
+        content: [
+          { type: 'mention', attrs: { id: donor.id, label: donor.username } },
+          { type: 'text', text: ' ' },
+        ],
+      },
+    ],
+  }
+  const editor = useTextEditor(
+    startingText,
+    storageKey,
+    `Say thanks to ${donor.full_name}...`,
+    'border-0 focus:!outline-none focus:ring-0 text-sm sm:text-md'
+  )
+  const handleSubmit = async () => {
+    const content = editor?.getJSON() as JSONContent | undefined
+    if (!editor || !editor.getText()?.trim() || !content) return
+    setIsSubmitting(true)
+    await fetch('/api/post-comment', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ content, projectId: replyContext.projectId }),
+    })
+    editor.commands.clearContent()
+    clearLocalStorageItem(storageKey)
+    setIsSubmitting(false)
+    onClose()
+    router.push(`/projects/${replyContext.projectSlug}?tab=comments`)
+    router.refresh()
+  }
+  return (
+    <div className="relative w-full overflow-hidden rounded-xl rounded-tl-sm bg-white p-0 shadow">
+      <TextEditor editor={editor}>
+        <div className="py-1" aria-hidden="true">
+          <div className="py-px">
+            <div className="h-9" />
+          </div>
+        </div>
+        <Row className="absolute bottom-0 w-full items-center justify-between border-t border-t-gray-200 bg-white py-0.5 pl-3">
+          <button
+            onClick={onClose}
+            className="text-sm text-gray-500 hover:cursor-pointer hover:text-gray-700"
+          >
+            Cancel
+          </button>
+          <IconButton
+            loading={isSubmitting}
+            onClick={async () => {
+              await handleSubmit()
+            }}
+          >
+            <PaperAirplaneIcon className="h-6 w-6 text-gray-500 hover:cursor-pointer hover:text-orange-500" />
+          </IconButton>
+        </Row>
+      </TextEditor>
+    </div>
   )
 }


### PR DESCRIPTION
response to https://discord.com/channels/1111727151071371454/1133818254394142820/1533854266631127170 

The idea is:
- project creator, when viewing donations, has an option to "reply"
- this creates an empty comment in the comments section that just shows the donor and amount donated
- the creator's reply shows up as a reply on the comment thread
- it causes the donor to get a notification (but not everyone following the project)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Project creators can reply directly to individual donations.
  * Replies support donor mentions and are posted from the donation history.
  * After submitting a reply, the app closes the editor, navigates to project comments, and refreshes the page.

* **Enhancements**
  * Donation history now carries relevant project and creator context to support replies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->